### PR TITLE
Protect from potential NPE from playerView

### DIFF
--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -145,15 +145,23 @@ public class MuxBaseExoPlayer extends EventBus implements IPlayerListener {
 
     @Override
     public int getPlayerViewWidth() {
-        if (this.playerView != null)
-            return this.playerView.get().getWidth();
+        if (this.playerView != null) {
+            View pv = this.playerView.get();
+            if (pv != null) {
+                return pv.getWidth();
+            }
+        }
         return 0;
     }
 
     @Override
     public int getPlayerViewHeight() {
-        if (this.playerView != null)
-            return this.playerView.get().getHeight();
+        if (this.playerView != null) {
+            View pv = this.playerView.get();
+            if (pv != null) {
+                return pv.getHeight();
+            }
+        }
         return 0;
     }
 


### PR DESCRIPTION
Small change to retrieve the `View` from our `WeakReference` and ensure it is not `null` before calling `getWidth` and `getHeight` on it, just to be safe.