### PR TITLE
make sure to only set properties on loadData if not null

### DIFF
--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -208,7 +208,7 @@ public class MuxBaseExoPlayer extends EventBus implements IPlayerListener {
 
     static class MuxDevice implements IDevice {
         private static final String MUX_PLUGIN_NAME = "android-mux";
-        private static final String MUX_PLUGIN_VERSION = "0.4.2";
+        private static final String MUX_PLUGIN_VERSION = "0.4.3";
         private static final String EXO_SOFTWARE = "ExoPlayer";
 
         private String deviceId;

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -417,9 +417,9 @@ public class MuxBaseExoPlayer extends EventBus implements IPlayerListener {
                     default:
                         break;
                 }
+                if (trackFormat != null)
+                    loadData.setRequestLabeledBitrate(trackFormat.bitrate);
             }
-            if (trackFormat != null)
-                loadData.setRequestLabeledBitrate(trackFormat.bitrate);
             return loadData;
         }
     }

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## v0.4.3
+ - Fix an issue where a NullPointerException may occur during playback of a video while tracking bandwidth metrics.
+
+## v0.4.2
+ - Added API method `programChange(CustomerVideoData customerVideoData)`, for use when inside of a single stream the program changes. For instance, in a 24/7 live stream, you may have metadata indicating program changes which should be tracked as separate views within Mux. Previously, `videoChange` might have been used for this case, but this would not work correctly, and you would not necessarily have seen the subsequent views show up. See [the documentation](https://docs.mux.com/docs/android-integration-guide#section-6-changing-the-video) for full explanation.
+ - Fixed a bug where under poor network conditions, an exception raised as a result of a network request could result in not tracking the view correctly subsequently (such as missing rebuffer tracking after this point).
+
 ## v0.4.1
 - Remove the listeners on the `ExoPlayer` object when `release` is called.
   - This fixes and issue where the application may crash after calling release


### PR DESCRIPTION
A customer reported the following crash (de-obfuscated, and redacted slightly for customer information):

```
07-30 20:16:22.767 E/UncaughtException: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.mux.stats.sdk.core.model.a.e(java.lang.Integer)' on a null object reference
        at com.mux.stats.sdk.muxstats.MuxBaseExoPlayer$BandwidthMetricHls.com.mux.stats.sdk.core.model.BandwidthMetricData onLoadCompleted(com.google.android.exoplayer2.upstream.DataSpec,int,com.google.android.exoplayer2.Format,long,long,long,long,long)(MuxBaseExoPlayer.java)
        at com.mux.stats.sdk.muxstats.MuxBaseExoPlayer$BandwidthMetricDispatcher.com.mux.stats.sdk.muxstats.MuxBaseExoPlayer$BandwidthMetric currentBandwidthMetric()(MuxBaseExoPlayer.java)
                                                                                 void onLoadError(com.google.android.exoplayer2.upstream.DataSpec,int,java.io.IOException)(MuxBaseExoPlayer.java)
                                                                                      onLoadCanceled(com.google.android.exoplayer2.upstream.DataSpec)(MuxBaseExoPlayer.java)
                                                                                      onLoadStarted(com.google.android.exoplayer2.upstream.DataSpec,int,com.google.android.exoplayer2.Format,long,long,long)(MuxBaseExoPlayer.java)
                                                                                      onLoadCompleted(com.google.android.exoplayer2.upstream.DataSpec,int,com.google.android.exoplayer2.Format,long,long,long,long,long)(MuxBaseExoPlayer.java)
                                                                                      onTracksChanged(com.google.android.exoplayer2.source.TrackGroupArray)(MuxBaseExoPlayer.java)
                                                                                      dispatch(com.mux.stats.sdk.core.model.BandwidthMetricData)(MuxBaseExoPlayer.java)
        at com.mux.stats.sdk.muxstats.MuxStatsExoPlayer.void onLoadCompleted(com.google.android.exoplayer2.upstream.DataSpec,int,int,com.google.android.exoplayer2.Format,int,java.lang.Object,long,long,long,long,long)(MuxStatsExoPlayer.java)
        at com.google.android.exoplayer2.source.AdaptiveMediaSourceEventListener$EventDispatcher$2.null run(null)(AdaptiveMediaSourceEventListener.java:226)
        at android.os.Handler.null handleCallback(null)(Handler.java:739)
        at android.os.Handler.null dispatchMessage(null)(Handler.java:95)
        at android.os.Looper.null loop(null)(Looper.java:211)
        at android.app.ActivityThread.null main(null)(ActivityThread.java:5335)
        at java.lang.reflect.Method.null invoke(null)(Method.java)
        at java.lang.reflect.Method.null invoke(null)(Method.java:372)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.null run(null)(ZygoteInit.java:1016)
        at com.android.internal.os.ZygoteInit.null main(null)(ZygoteInit.java:811)
07-30 20:16:22.798 I/ExtendedCodec: Decoder will be in frame by frame mode
07-30 20:16:22.816 D/ACodec: Found video-output-protection flags set to 00000000
07-30 20:16:22.866 I/OMXClient: Using client-side OMX mux.
07-30 20:16:22.893 E/OMXMaster: A component of name 'OMX.qcom.audio.decoder.aac' already exists, ignoring this one.
07-30 20:16:22.895 D/MediaCodec: MediaCodec[kWhatConfigure]: video-output-protection: 00000000, audio-output-protection: 00000000
07-30 20:16:22.899 I/SoftAAC2: Reconfiguring decoder: 0->44100 Hz, 0->2 channels
07-30 20:16:22.909 W/ACodec: do not know color format 0x7fa30c04 = 2141391876
07-30 20:16:22.910 D/AudioTrack: TrackOffload: AudioTrack Offload disabled by property, returning false
07-30 20:16:23.002 E/AndroidRuntime: FATAL EXCEPTION: main
    Process: process, PID: 29996
    java.lang.NullPointerException: Attempt to invoke virtual method 'void com.mux.stats.sdk.core.model.a.e(java.lang.Integer)' on a null object reference
        at com.mux.stats.sdk.muxstats.MuxBaseExoPlayer$BandwidthMetricHls.com.mux.stats.sdk.core.model.BandwidthMetricData onLoadCompleted(com.google.android.exoplayer2.upstream.DataSpec,int,com.google.android.exoplayer2.Format,long,long,long,long,long)(MuxBaseExoPlayer.java)
        at com.mux.stats.sdk.muxstats.MuxBaseExoPlayer$BandwidthMetricDispatcher.com.mux.stats.sdk.muxstats.MuxBaseExoPlayer$BandwidthMetric currentBandwidthMetric()(MuxBaseExoPlayer.java)
                                                                                 void onLoadError(com.google.android.exoplayer2.upstream.DataSpec,int,java.io.IOException)(MuxBaseExoPlayer.java)
                                                                                      onLoadCanceled(com.google.android.exoplayer2.upstream.DataSpec)(MuxBaseExoPlayer.java)
                                                                                      onLoadStarted(com.google.android.exoplayer2.upstream.DataSpec,int,com.google.android.exoplayer2.Format,long,long,long)(MuxBaseExoPlayer.java)
                                                                                      onLoadCompleted(com.google.android.exoplayer2.upstream.DataSpec,int,com.google.android.exoplayer2.Format,long,long,long,long,long)(MuxBaseExoPlayer.java)
                                                                                      onTracksChanged(com.google.android.exoplayer2.source.TrackGroupArray)(MuxBaseExoPlayer.java)
                                                                                      dispatch(com.mux.stats.sdk.core.model.BandwidthMetricData)(MuxBaseExoPlayer.java)
        at com.mux.stats.sdk.muxstats.MuxStatsExoPlayer.void onLoadCompleted(com.google.android.exoplayer2.upstream.DataSpec,int,int,com.google.android.exoplayer2.Format,int,java.lang.Object,long,long,long,long,long)(MuxStatsExoPlayer.java)
        at com.google.android.exoplayer2.source.AdaptiveMediaSourceEventListener$EventDispatcher$2.null run(null)(AdaptiveMediaSourceEventListener.java:226)
        at android.os.Handler.null handleCallback(null)(Handler.java:739)
        at android.os.Handler.null dispatchMessage(null)(Handler.java:95)
        at android.os.Looper.null loop(null)(Looper.java:211)
        at android.app.ActivityThread.null main(null)(ActivityThread.java:5335)
        at java.lang.reflect.Method.null invoke(null)(Method.java)
        at java.lang.reflect.Method.null invoke(null)(Method.java:372)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.null run(null)(ZygoteInit.java:1016)
        at com.android.internal.os.ZygoteInit.null main(null)(ZygoteInit.java:811)
```

It appears that the root of the issue is a potential to call `loadData.setRequestLabeledBitrate()` outside of a check for `loadData` being `null`. This PR tries to guard against this.