### PR TITLE
make sure to raise an exception if methods are called after release

### DIFF
--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -67,15 +67,23 @@ public class MuxBaseExoPlayer extends EventBus implements IPlayerListener {
         addListener(muxStats);
     }
 
+    private void checkNotReleased() {
+        if (muxStats == null) {
+            throw new IllegalStateException("The MuxStats monitor has already been released.");
+        }
+    }
+
     public AdsImaSDKListener getIMASdkListener() {
         return new AdsImaSDKListener(this);
     }
 
     public void videoChange(CustomerVideoData customerVideoData) {
+        checkNotReleased();
         muxStats.videoChange(customerVideoData);
     }
 
     public void programChange(CustomerVideoData customerVideoData) {
+        checkNotReleased();
         muxStats.programChange(customerVideoData);
     }
 
@@ -84,22 +92,27 @@ public class MuxBaseExoPlayer extends EventBus implements IPlayerListener {
     }
 
     public void setPlayerSize(int width, int height) {
+        checkNotReleased();
         muxStats.setPlayerSize(width, height);
     }
 
     public void setScreenSize(int width, int height) {
+        checkNotReleased();
         muxStats.setScreenSize(width, height);
     }
 
     public void error(MuxErrorException e) {
+        checkNotReleased();
         muxStats.error(e);
     }
 
     public void setAutomaticErrorTracking(boolean enabled) {
+        checkNotReleased();
         muxStats.setAutomaticErrorTracking(enabled);
     }
 
     public void release() {
+        checkNotReleased();
         muxStats.release();
         muxStats = null;
         player = null;


### PR DESCRIPTION
To guard against NPEs that are raised if one tries to call an instance method like `setScreenSize`, we should raise a more intentional exception so people can react to it appropriately.