### PR TITLE
Add missing overrides for AnalyticsListener on 2.10.6

### DIFF
--- a/MuxExoPlayer/src/r2_10_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_10_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -359,4 +359,29 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
     public void onSeekProcessed() {
 
     }
+    
+    @Override
+    public void onSurfaceSizeChanged(AnalyticsListener.EventTime eventTime, int width, int height) {
+    
+    }
+
+    @Override
+    public void onIsPlayingChanged(AnalyticsListener.EventTime eventTime, boolean isPlaying) {
+    
+    }
+
+    @Override
+    public void onAudioAttributesChanged(AnalyticsListener.EventTime eventTime, AudioAttributes audioAttributes) {
+    
+    }
+
+    @Override
+    public void onPlaybackSuppressionReasonChanged(AnalyticsListener.EventTime eventTime, int playbackSuppressionReason) {
+    
+    }
+
+    @Override
+    public void onVolumeChanged(AnalyticsListener.EventTime eventTime, float volume) {
+    
+    }
 }


### PR DESCRIPTION
Current Mux library fails with errors like
```
java.lang.AbstractMethodError: abstract method "void com.google.android.exoplayer2.analytics.AnalyticsListener.onIsPlayingChanged(com.google.android.exoplayer2.analytics.AnalyticsListener$EventTime, boolean)"
```