### PR TITLE
Use repackageclasses to avoid proguard generate classes which could conflict with other libraries.

### DIFF
--- a/MuxExoPlayer/proguard-rules.pro
+++ b/MuxExoPlayer/proguard-rules.pro
@@ -24,3 +24,5 @@
 -keep public class com.mux.stats.sdk.core.model.CustomerPlayerData { public protected *; }
 -keep public class com.mux.stats.sdk.core.model.CustomerVideoData { public protected *; }
 -keep public class com.mux.stats.sdk.core.MuxSDKViewOrientation { public protected *; }
+
+-repackageclasses com.mux.stats.sdk


### PR DESCRIPTION
This is a fix for https://github.com/muxinc/mux-stats-sdk-exoplayer/issues/62 issue.
After this, we don't have a.a.a.a.a.a classes, conflicting with other libraries.

I did attached mapping files (generated after applying this fix), so it's easy/faster to compare with mapping files from 2.0.0 release and see differences.

[mapping-r2.9.6.txt](https://github.com/muxinc/mux-stats-sdk-exoplayer/files/5591041/mapping-r2.9.6.txt)
[mapping-r2.10.6.txt](https://github.com/muxinc/mux-stats-sdk-exoplayer/files/5591043/mapping-r2.10.6.txt)
[mapping-r2.11.1.txt](https://github.com/muxinc/mux-stats-sdk-exoplayer/files/5591044/mapping-r2.11.1.txt)
