### PR TITLE
v2.3.0 with release notes

### DIFF
--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -6,7 +6,7 @@ android {
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
         versionCode 9
-        versionName "2.2.0"
+        versionName "2.3.0"
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## v2.3.0
+ - Fix an issue where logical resolution was calculated incorrectly
+ - Report `wired` instead of `ethernet` for certain connection types
+ - [internal] Integrate automated integration tests
+
 ## v2.2.0
  - Upgrade to Android Studio 4.1
  - Upgrade to Gradle 6.1.1

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -14,7 +14,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField("boolean", "SHOULD_REPORT_INSTRUMENTATION_TEST_EVENTS_TO_SERVER", "true")
-        buildConfigField("String", "INSTRUMENTATION_TEST_ENVIRONMENT_KEY", "\"bar8fjevgudvf4o7r8fdjrfii\"")
+        buildConfigField("String", "INSTRUMENTATION_TEST_ENVIRONMENT_KEY", "\"YOUR_ENV_KEY_HERE\"")
     }
 
     buildTypes {


### PR DESCRIPTION
 - Fix an issue where logical resolution was calculated incorrectly
 - Report `wired` instead of `ethernet` for certain connection types
 - [internal] Integrate automated integration tests
 - v2.3.0