### PR TITLE
Handle renderer errors that are not of type DecoderInitializationException

### DIFF
--- a/MuxExoPlayer/src/r2_10_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_10_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -389,6 +389,9 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                     internalError(new MuxErrorException(e.type, "Unable to instantiate decoder for " + die.mimeType));
                 }
             }
+            else {
+                internalError(new MuxErrorException(e.type, cause.getClass().getCanonicalName() + " - " + cause.getMessage()));
+            }
         } else if (e.type == ExoPlaybackException.TYPE_SOURCE) {
             Exception error = e.getSourceException();
             internalError(new MuxErrorException(e.type, error.getClass().getCanonicalName() + " - " + error.getMessage()));

--- a/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -388,6 +388,9 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                     internalError(new MuxErrorException(e.type, "Unable to instantiate decoder for " + die.mimeType));
                 }
             }
+            else {
+                internalError(new MuxErrorException(e.type, cause.getClass().getCanonicalName() + " - " + cause.getMessage()));
+            }
         } else if (e.type == ExoPlaybackException.TYPE_SOURCE) {
             Exception error = e.getSourceException();
             internalError(new MuxErrorException(e.type, error.getClass().getCanonicalName() + " - " + error.getMessage()));

--- a/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -376,7 +376,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
             Exception cause = e.getRendererException();
             if (cause instanceof MediaCodecRenderer.DecoderInitializationException) {
                 MediaCodecRenderer.DecoderInitializationException die = (MediaCodecRenderer.DecoderInitializationException) cause;
-                if (die.codecInfo != null && die.codecInfo.name == null) {
+                if (die.codecInfo == null) {
                     if (die.getCause() instanceof MediaCodecUtil.DecoderQueryException) {
                         internalError(new MuxErrorException(e.type, "Unable to query device decoders"));
                     } else if (die.secureDecoderRequired) {

--- a/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -338,6 +338,9 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                     internalError(new MuxErrorException(e.type, "Unable to instantiate decoder for " + die.mimeType));
                 }
             }
+            else {
+                internalError(new MuxErrorException(e.type, cause.getClass().getCanonicalName() + " - " + cause.getMessage()));
+            }
         } else if (e.type == ExoPlaybackException.TYPE_SOURCE) {
             Exception error = e.getSourceException();
             internalError(new MuxErrorException(e.type, error.getClass().getCanonicalName() + " - " + error.getMessage()));

--- a/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -326,7 +326,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
             Exception cause = e.getRendererException();
             if (cause instanceof MediaCodecRenderer.DecoderInitializationException) {
                 MediaCodecRenderer.DecoderInitializationException die = (MediaCodecRenderer.DecoderInitializationException) cause;
-                if (die.codecInfo != null && die.codecInfo.name == null) {
+                if (die.codecInfo == null) {
                     if (die.getCause() instanceof MediaCodecUtil.DecoderQueryException) {
                         internalError(new MuxErrorException(e.type, "Unable to query device decoders"));
                     } else if (die.secureDecoderRequired) {

--- a/MuxExoPlayer/src/r2_9_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_9_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -387,6 +387,9 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                     internalError(new MuxErrorException(e.type, "Unable to instantiate decoder for " + die.mimeType));
                 }
             }
+            else {
+                internalError(new MuxErrorException(e.type, cause.getClass().getCanonicalName() + " - " + cause.getMessage()));
+            }
         } else if (e.type == ExoPlaybackException.TYPE_SOURCE) {
             Exception error = e.getSourceException();
             internalError(new MuxErrorException(e.type, error.getClass().getCanonicalName() + " - " + error.getMessage()));


### PR DESCRIPTION
This should resolve #72 

------------------------

- Handle renderer errors that are not of type `DecoderInitializationException`
- We should look for missing `codecInfo` and not for `codecInfo.name`. Missing `codecInfo` that implies we failed to find a suitable decoder. `codecInfo.name` will never be null. See https://github.com/google/ExoPlayer/blob/release-v2/library/core/src/main/java/com/google/android/exoplayer2/mediacodec/MediaCodecInfo.java#L169