### PR TITLE
Run two Saucelabs tests at a time, add Android 11 tests

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -23,7 +23,6 @@ steps:
         download:
           - "automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk"
           - "automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk"
-- wait
 - agents: [dind=true,queue=beta]
   command: docker run --rm -v "$PWD":/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucelabs-virtual-test-runner:0.1.2
   label: Test Exoplayer r2_10_6 on Android GoogleAPI Emulator, platform-version 10.0
@@ -49,10 +48,34 @@ steps:
         download:
           - "automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk"
           - "automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk"
-- wait
 - agents: [dind=true,queue=beta]
   command: docker run --rm -v "$PWD":/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucelabs-virtual-test-runner:0.1.2
   label: Test Exoplayer r2_12_1 on Android GoogleAPI Emulator, platform-version 10.0
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk"
+- wait
+- agents: [dind=true,queue=beta]
+  command: docker run --rm -v "$PWD":/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY -e DEVICES="deviceName=Android GoogleAPI Emulator,platformVersion=11.0" muxinc/saucelabs-virtual-test-runner:0.1.2
+  label: Test Exoplayer r2_11_1 on Android GoogleAPI Emulator, platform-version 11.0
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk"
+- agents: [dind=true,queue=beta]
+  command: docker run --rm -v "$PWD":/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY -e DEVICES="deviceName=Android GoogleAPI Emulator,platformVersion=11.0" muxinc/saucelabs-virtual-test-runner:0.1.2
+  label: Test Exoplayer r2_12_1 on Android GoogleAPI Emulator, platform-version 11.0
   retry:
     automatic:
       - exit_status: 1

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,6 +1,6 @@
 steps:
 - agents: [dind=true,queue=beta]
-  command: docker run -it --rm -v "$PWD":/data -w="/data" muxinc/mux-exoplayer:20201215 bash -c "./gradlew --info clean build assemble automatedtests:assembleAndroidTest"
+  command: docker run -it --rm -v $(pwd):/data -w="/data" muxinc/mux-exoplayer:20201215 bash -c "./gradlew --info clean build assemble automatedtests:assembleAndroidTest"
   label: Build AARs and APKs
   plugins:
     - artifacts#v1.3.0:
@@ -12,7 +12,7 @@ steps:
           - "automatedtests/buildout/outputs/apk/*/debug/automatedtests-*-debug.apk"
 - wait
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v "$PWD":/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucelabs-virtual-test-runner:0.1.2
+  command: docker run --rm -v $(pwd):/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucelabs-virtual-test-runner:0.1.2
   label: Test Exoplayer r2_9_6 on Android GoogleAPI Emulator, platform-version 10.0
   retry:
     automatic:
@@ -24,7 +24,7 @@ steps:
           - "automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk"
           - "automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk"
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v "$PWD":/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucelabs-virtual-test-runner:0.1.2
+  command: docker run --rm -v $(pwd):/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucelabs-virtual-test-runner:0.1.2
   label: Test Exoplayer r2_10_6 on Android GoogleAPI Emulator, platform-version 10.0
   retry:
     automatic:
@@ -37,7 +37,7 @@ steps:
           - "automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk"
 - wait
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v "$PWD":/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucelabs-virtual-test-runner:0.1.2
+  command: docker run --rm -v $(pwd):/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucelabs-virtual-test-runner:0.1.2
   label: Test Exoplayer r2_11_1 on Android GoogleAPI Emulator, platform-version 10.0
   retry:
     automatic:
@@ -49,7 +49,7 @@ steps:
           - "automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk"
           - "automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk"
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v "$PWD":/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucelabs-virtual-test-runner:0.1.2
+  command: docker run --rm -v $(pwd):/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucelabs-virtual-test-runner:0.1.2
   label: Test Exoplayer r2_12_1 on Android GoogleAPI Emulator, platform-version 10.0
   retry:
     automatic:
@@ -62,7 +62,7 @@ steps:
           - "automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk"
 - wait
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v "$PWD":/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY -e DEVICES="deviceName=Android GoogleAPI Emulator,platformVersion=11.0" muxinc/saucelabs-virtual-test-runner:0.1.2
+  command: docker run --rm -v $(pwd):/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY -e DEVICES="deviceName=Android GoogleAPI Emulator,platformVersion=11.0" muxinc/saucelabs-virtual-test-runner:0.1.2
   label: Test Exoplayer r2_11_1 on Android GoogleAPI Emulator, platform-version 11.0
   retry:
     automatic:
@@ -74,7 +74,7 @@ steps:
           - "automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk"
           - "automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk"
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v "$PWD":/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY -e DEVICES="deviceName=Android GoogleAPI Emulator,platformVersion=11.0" muxinc/saucelabs-virtual-test-runner:0.1.2
+  command: docker run --rm -v $(pwd):/data -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY -e DEVICES="deviceName=Android GoogleAPI Emulator,platformVersion=11.0" muxinc/saucelabs-virtual-test-runner:0.1.2
   label: Test Exoplayer r2_12_1 on Android GoogleAPI Emulator, platform-version 11.0
   retry:
     automatic:


### PR DESCRIPTION
Run two Saucelabs tests in parallel to speed up the overall build. Run Exoplayer 2.11 and 2.12 tests on Android 11.

Also, correct the expansion of the `pwd` command so that it runs on the Buildkite agent responsible for each step, not the agent that formulates the overall build plan at the start of the build. This bug caused build failures if the steps ended up running on different agents.