### PR TITLE
[FIX] Propagate customerViewData constructor arg.

### DIFF
--- a/MuxExoPlayer/src/r2_10_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_10_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -52,7 +52,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                              CustomerPlayerData customerPlayerData,
                              CustomerVideoData customerVideoData,
                              CustomerViewData customerViewData, boolean sentryEnabled) {
-        this(ctx, player, playerName, customerPlayerData, customerVideoData, null,
+        this(ctx, player, playerName, customerPlayerData, customerVideoData, customerViewData,
                 sentryEnabled, new MuxNetworkRequests());
     }
 


### PR DESCRIPTION
The `customerViewData` constructor arg was not being passed, which could lead to view-session-id not being sent.