### PR TITLE
pass CustomerViewData through all constructors

### DIFF
--- a/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -52,7 +52,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                              CustomerPlayerData customerPlayerData,
                              CustomerVideoData customerVideoData,
                              CustomerViewData customerViewData, boolean sentryEnabled) {
-        this(ctx, player, playerName, customerPlayerData, customerVideoData, null,
+        this(ctx, player, playerName, customerPlayerData, customerVideoData, customerViewData,
                 sentryEnabled, new MuxNetworkRequests());
     }
 

--- a/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -57,7 +57,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                              CustomerVideoData customerVideoData,
                              CustomerViewData customerViewData, boolean sentryEnabled) {
         this(ctx, player, playerName, customerPlayerData, customerVideoData,
-                null, sentryEnabled, new MuxNetworkRequests());
+                customerViewData, sentryEnabled, new MuxNetworkRequests());
     }
 
     public MuxStatsExoPlayer(Context ctx, ExoPlayer player, String playerName,

--- a/MuxExoPlayer/src/r2_9_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_9_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -51,7 +51,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                              CustomerPlayerData customerPlayerData,
                              CustomerVideoData customerVideoData,
                              CustomerViewData customerViewData, boolean sentryEnabled) {
-        this(ctx, player, playerName, customerPlayerData, customerVideoData, null,
+        this(ctx, player, playerName, customerPlayerData, customerVideoData, customerViewData,
                 sentryEnabled, new MuxNetworkRequests());
     }
 


### PR DESCRIPTION
The constructors for 2.9.6, 2.11.1, and 2.12.1 also need us to pass through CustomerViewData as well.