### PR TITLE
v2.4.3

### DIFF
--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -5,8 +5,8 @@ android {
     defaultConfig {
         minSdkVersion project.ext.minSdkVersion
         targetSdkVersion project.ext.targetSdkVersion
-        versionCode 13
-        versionName "2.4.2"
+        versionCode 14
+        versionName "2.4.3"
         multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -52,7 +52,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                              CustomerPlayerData customerPlayerData,
                              CustomerVideoData customerVideoData,
                              CustomerViewData customerViewData, boolean sentryEnabled) {
-        this(ctx, player, playerName, customerPlayerData, customerVideoData, null,
+        this(ctx, player, playerName, customerPlayerData, customerVideoData, customerViewData,
                 sentryEnabled, new MuxNetworkRequests());
     }
 

--- a/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -57,7 +57,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                              CustomerVideoData customerVideoData,
                              CustomerViewData customerViewData, boolean sentryEnabled) {
         this(ctx, player, playerName, customerPlayerData, customerVideoData,
-                null, sentryEnabled, new MuxNetworkRequests());
+                customerViewData, sentryEnabled, new MuxNetworkRequests());
     }
 
     public MuxStatsExoPlayer(Context ctx, ExoPlayer player, String playerName,

--- a/MuxExoPlayer/src/r2_9_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_9_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -51,7 +51,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
                              CustomerPlayerData customerPlayerData,
                              CustomerVideoData customerVideoData,
                              CustomerViewData customerViewData, boolean sentryEnabled) {
-        this(ctx, player, playerName, customerPlayerData, customerVideoData, null,
+        this(ctx, player, playerName, customerPlayerData, customerVideoData, customerViewData,
                 sentryEnabled, new MuxNetworkRequests());
     }
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,5 +1,8 @@
 # Release notes
 
+## v2.4.3
+ - Propagate `customerViewData` through the constructors for 2.9.6, 2.11.1, and 2.12.1 as well.
+
 ## v2.4.2
  - Fix propagation of `customerViewData` through all constructors.
 


### PR DESCRIPTION
 - Propagate `customerViewData` through the constructors for 2.9.6, 2.11.1, and 2.12.1 as well.
