### PR TITLE
reset state when calling videochange

### DIFF
--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -244,6 +244,8 @@ public class MuxBaseExoPlayer extends EventBus implements IPlayerListener {
 
   @SuppressWarnings("unused")
   public void videoChange(CustomerVideoData customerVideoData) {
+    // Reset the state to avoid unwanted rebuffering events
+    state = PlayerState.INIT;
     resetInternalStats();
     muxStats.videoChange(customerVideoData);
   }
@@ -573,8 +575,7 @@ public class MuxBaseExoPlayer extends EventBus implements IPlayerListener {
     numberOfPauseEventsSent = 0;
     numberOfPlayEventsSent = 0;
     numberOfEventsSent = 0;
-    // Reset the state to avoid unwanted rebuffering events
-    state = PlayerState.INIT;
+
   }
 
   static class FrameRenderedListener implements VideoFrameMetadataListener {

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -573,6 +573,8 @@ public class MuxBaseExoPlayer extends EventBus implements IPlayerListener {
     numberOfPauseEventsSent = 0;
     numberOfPlayEventsSent = 0;
     numberOfEventsSent = 0;
+    // Reset the state to avoid unwanted rebuffering events
+    state = PlayerState.INIT;
   }
 
   static class FrameRenderedListener implements VideoFrameMetadataListener {

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -575,7 +575,6 @@ public class MuxBaseExoPlayer extends EventBus implements IPlayerListener {
     numberOfPauseEventsSent = 0;
     numberOfPlayEventsSent = 0;
     numberOfEventsSent = 0;
-
   }
 
   static class FrameRenderedListener implements VideoFrameMetadataListener {

--- a/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/PlaybackTests.java
+++ b/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/PlaybackTests.java
@@ -65,8 +65,8 @@ public class PlaybackTests extends TestBase {
       Thread.sleep(PAUSE_PERIOD_IN_MS);
       int rebufferStartEventIndex = 0;
       int rebufferEndEventIndex;
-      while ( (rebufferStartEventIndex = networkRequest.getIndexForNextEvent(
-          rebufferStartEventIndex, RebufferStartEvent.TYPE)) != -1 ) {
+      while ((rebufferStartEventIndex = networkRequest.getIndexForNextEvent(
+          rebufferStartEventIndex, RebufferStartEvent.TYPE)) != -1) {
         rebufferEndEventIndex = networkRequest.getIndexForNextEvent(rebufferStartEventIndex,
             RebufferEndEvent.TYPE);
         if (rebufferEndEventIndex == -1) {
@@ -75,11 +75,6 @@ public class PlaybackTests extends TestBase {
               + networkRequest.getReceivedEventNames());
         }
       }
-      // TODO check first segmment, check second segment
-      // Check basic playback events on first video
-//      int playEvntIndex = networkRequest.getIndexForFirstEvent(PlayEvent.TYPE);
-      // Check basic playback events on new video
-//      result = checkPausePeriodAtIndex(result.eventIndex, PAUSE_PERIOD_IN_MS);
     } catch (Exception e) {
       fail(getExceptionFullTraceAndMessage(e));
     }


### PR DESCRIPTION
To avoid a case where a rebufferstart event can be emitted whilst changing a video, we should consider resetting the state as part of calling videochange.

This means that when changing a video in the player, a customer should do the following:
```
// End the current view in Mux, ready to start the next view
CustomerVideoData customerVideoData = new CustomerVideoData();
customerVideoData.setVideoTitle("New Video");
muxStats.videoChange(customerVideoData);

// Set ExoPlayer up with the new video
MediaItem mediaItem = MediaItem.fromUri("https://example.com/some/new/video.mp4");
player.setMediaItem(mediaItem);
player.setPlayWhenReady(true);
player.prepare();
```