### PR TITLE
Nb muxcore obfuscation fix

### DIFF
--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -200,7 +200,7 @@ dependencies {
 
     // This is due to the problem with fat aar bundling
     // See item #1 https://github.com/kezong/fat-aar-android#known-defects-or-issues
-    def muxCoreImport = 'com.mux:stats.muxcore:7.0.1'
+    def muxCoreImport = 'com.mux:stats.muxcore:dev-nb-obfuscation-again-adb7d19'
     if(project.ext.inLocalDevMode) {
         api muxCoreImport
     } else {

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -200,7 +200,7 @@ dependencies {
 
     // This is due to the problem with fat aar bundling
     // See item #1 https://github.com/kezong/fat-aar-android#known-defects-or-issues
-    def muxCoreImport = 'com.mux:stats.muxcore:dev-nb-obfuscation-again-74c2c7c'
+    def muxCoreImport = 'com.mux:stats.muxcore:dev-nb-obfuscation-again-40fffb7'
     if(project.ext.inLocalDevMode) {
         api muxCoreImport
     } else {

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -200,7 +200,7 @@ dependencies {
 
     // This is due to the problem with fat aar bundling
     // See item #1 https://github.com/kezong/fat-aar-android#known-defects-or-issues
-    def muxCoreImport = 'com.mux:stats.muxcore:7.0.1'
+    def muxCoreImport = 'com.mux:stats.muxcore:dev-nb-obfuscation-again-5bf5093'
     if(project.ext.inLocalDevMode) {
         api muxCoreImport
     } else {

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -200,7 +200,7 @@ dependencies {
 
     // This is due to the problem with fat aar bundling
     // See item #1 https://github.com/kezong/fat-aar-android#known-defects-or-issues
-    def muxCoreImport = 'com.mux:stats.muxcore:dev-nb-obfuscation-again-40fffb7'
+    def muxCoreImport = 'com.mux:stats.muxcore:7.0.1'
     if(project.ext.inLocalDevMode) {
         api muxCoreImport
     } else {

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -200,7 +200,7 @@ dependencies {
 
     // This is due to the problem with fat aar bundling
     // See item #1 https://github.com/kezong/fat-aar-android#known-defects-or-issues
-    def muxCoreImport = 'com.mux:stats.muxcore:dev-nb-obfuscation-again-6f55393'
+    def muxCoreImport = 'com.mux:stats.muxcore:dev-nb-obfuscation-again-74c2c7c'
     if(project.ext.inLocalDevMode) {
         api muxCoreImport
     } else {

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -200,7 +200,7 @@ dependencies {
 
     // This is due to the problem with fat aar bundling
     // See item #1 https://github.com/kezong/fat-aar-android#known-defects-or-issues
-    def muxCoreImport = 'com.mux:stats.muxcore:dev-nb-obfuscation-again-5bf5093'
+    def muxCoreImport = 'com.mux:stats.muxcore:7.0.2'
     if(project.ext.inLocalDevMode) {
         api muxCoreImport
     } else {

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -200,7 +200,7 @@ dependencies {
 
     // This is due to the problem with fat aar bundling
     // See item #1 https://github.com/kezong/fat-aar-android#known-defects-or-issues
-    def muxCoreImport = 'com.mux:stats.muxcore:dev-nb-obfuscation-again-adb7d19'
+    def muxCoreImport = 'com.mux:stats.muxcore:dev-nb-obfuscation-again-6f55393'
     if(project.ext.inLocalDevMode) {
         api muxCoreImport
     } else {


### PR DESCRIPTION
This imports the updated MuxCore 7.0.2.

7.0.2 makes no API changes but does alter the obfuscation and the mechanism for transferring information about dependencies. 