### PR TITLE
Obfuscation and mapping

### DIFF
--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -44,7 +44,7 @@ android {
         }
 
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
This ensures mapping files are gathered as artefacts.

This was the result of a mistake on my part - during debugging MuxCore obfuscation I had disabled obfuscation of the Exoplayer SDK and not put it back: no obfuscation, no mapping! The renamed symbols were those seen from MuxCore.

The actual effect of this is fairly small as the number of renamed private fields outside of MuxCore isn't exactly high, but the files do contain items like "java.util.ArrayList allowedHeaders -> a" indicating it is working.

The buildkite test runs using this passed.