### PR TITLE
Problem with Exoplayer default implementation of methods on interfaces

### DIFF
--- a/MuxExoPlayer/src/r2_10_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_10_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -508,4 +508,14 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
   public void onVolumeChanged(AnalyticsListener.EventTime eventTime, float volume) {
 
   }
+
+  // Empty implementations of default methods from our interfaces
+  // This is to workaround https://github.com/google/ExoPlayer/issues/6801
+
+  @Override
+  @Deprecated
+  public void onDrmSessionAcquired(EventTime eventTime) {}
+
+  @Override
+  public void onDrmSessionReleased(EventTime eventTime) {}
 }

--- a/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -507,4 +507,14 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
   public void onVolumeChanged(AnalyticsListener.EventTime eventTime, float volume) {
 
   }
+
+  // Empty implementations of default methods from our interfaces
+  // This is to workaround https://github.com/google/ExoPlayer/issues/6801
+
+  @Override
+  @Deprecated
+  public void onDrmSessionAcquired(EventTime eventTime) {}
+
+  @Override
+  public void onDrmSessionReleased(EventTime eventTime) {}
 }

--- a/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -457,4 +457,68 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
     bandwidthDispatcher.onTracksChanged(trackGroups);
     configurePlaybackHeadUpdateInterval();
   }
+
+  // Empty implementations of default methods from our interfaces
+  // This is to workaround https://github.com/google/ExoPlayer/issues/6801
+
+  @Override
+  @Deprecated
+  public void onPlayerStateChanged(
+      EventTime eventTime, boolean playWhenReady, @Player.State int playbackState) {}
+
+  @Override
+  @Deprecated
+  public void onSeekProcessed(EventTime eventTime) {}
+
+  @Override
+  @Deprecated
+  public void onLoadingChanged(EventTime eventTime, boolean isLoading) {}
+
+  @Override
+  public void onBandwidthEstimate(
+      EventTime eventTime, int totalLoadTimeMs, long totalBytesLoaded, long bitrateEstimate) {}
+
+  @Override
+  @Deprecated
+  public void onDecoderInitialized(
+      EventTime eventTime, int trackType, String decoderName, long initializationDurationMs) {}
+
+  @Override
+  @Deprecated
+  public void onDecoderInputFormatChanged(EventTime eventTime, int trackType, Format format) {}
+
+  @Override
+  @Deprecated
+  public void onAudioDecoderInitialized(
+      EventTime eventTime, String decoderName, long initializationDurationMs) {}
+
+  @Override
+  @Deprecated
+  public void onAudioInputFormatChanged(EventTime eventTime, Format format) {}
+
+  @Override
+  public void onAudioPositionAdvancing(EventTime eventTime, long playoutStartSystemTimeMs) {}
+
+  @Override
+  public void onSkipSilenceEnabledChanged(EventTime eventTime, boolean skipSilenceEnabled) {}
+
+  @Override
+  @Deprecated
+  public void onVideoDecoderInitialized(
+      EventTime eventTime, String decoderName, long initializationDurationMs) {}
+
+  @Override
+  public void onDroppedVideoFrames(EventTime eventTime, int droppedFrames, long elapsedMs) {}
+
+  @Override
+  public void onVideoFrameProcessingOffset(
+      EventTime eventTime, long totalProcessingOffsetUs, int frameCount) {}
+
+  @Override
+  @Deprecated
+  public void onDrmSessionAcquired(EventTime eventTime) {}
+
+  @Override
+  public void onDrmSessionReleased(EventTime eventTime) {}
+
 }

--- a/MuxExoPlayer/src/r2_13_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_13_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -2,15 +2,22 @@ package com.mux.stats.sdk.muxstats;
 
 import android.content.Context;
 import android.view.Surface;
+import androidx.annotation.Nullable;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.MediaItem;
+import com.google.android.exoplayer2.MediaMetadata;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.Player.DiscontinuityReason;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.analytics.AnalyticsListener;
 import com.google.android.exoplayer2.audio.AudioAttributes;
+import com.google.android.exoplayer2.decoder.DecoderCounters;
+import com.google.android.exoplayer2.decoder.DecoderReuseEvaluation;
+import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.mediacodec.MediaCodecRenderer;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 import com.google.android.exoplayer2.metadata.Metadata;
@@ -26,6 +33,7 @@ import com.mux.stats.sdk.core.model.CustomerVideoData;
 import com.mux.stats.sdk.core.model.CustomerViewData;
 import com.mux.stats.sdk.core.util.MuxLogger;
 import java.io.IOException;
+import java.util.List;
 
 public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsListener,
     Player.EventListener {
@@ -315,13 +323,6 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onUpstreamDiscarded(EventTime eventTime, MediaLoadData mediaLoadData) {
-  }
-
-  @Override
-  public void onVideoSizeChanged(AnalyticsListener.EventTime eventTime, int width, int height,
-      int unappliedRotationDegrees, float pixelWidthHeightRatio) {
-    sourceWidth = width;
-    sourceHeight = height;
   }
 
   @Override

--- a/MuxExoPlayer/src/r2_13_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_13_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -326,6 +326,13 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
   }
 
   @Override
+  public void onVideoSizeChanged(AnalyticsListener.EventTime eventTime, int width, int height,
+      int unappliedRotationDegrees, float pixelWidthHeightRatio) {
+    sourceWidth = width;
+    sourceHeight = height;
+  }
+
+  @Override
   public void onVolumeChanged(AnalyticsListener.EventTime eventTime, float volume) {
   }
   // ------END AnalyticsListener callbacks------
@@ -454,4 +461,128 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
     bandwidthDispatcher.onTracksChanged(trackGroups);
     configurePlaybackHeadUpdateInterval();
   }
+
+  // Empty implementations of default methods from our interfaces
+  // This is to workaround https://github.com/google/ExoPlayer/issues/6801
+
+  @Override
+  @Deprecated
+  public void onPlayerStateChanged(
+      EventTime eventTime, boolean playWhenReady, @Player.State int playbackState) {}
+
+  @Override
+  public void onMediaItemTransition(
+      EventTime eventTime,
+      @Nullable MediaItem mediaItem,
+      @Player.MediaItemTransitionReason int reason) {}
+
+  @Override
+  @Deprecated
+  public void onSeekProcessed(EventTime eventTime) {}
+
+  @Override
+  @Deprecated
+  public void onLoadingChanged(EventTime eventTime, boolean isLoading) {}
+
+  @Override
+  public void onStaticMetadataChanged(EventTime eventTime, List<Metadata> metadataList) {}
+
+  @Override
+  public void onBandwidthEstimate(
+      EventTime eventTime, int totalLoadTimeMs, long totalBytesLoaded, long bitrateEstimate) {}
+
+  @Override
+  @Deprecated
+  public void onDecoderEnabled(
+      EventTime eventTime, int trackType, DecoderCounters decoderCounters) {}
+
+  @Override
+  @Deprecated
+  public void onDecoderInitialized(
+      EventTime eventTime, int trackType, String decoderName, long initializationDurationMs) {}
+
+  @Override
+  @Deprecated
+  public void onDecoderInputFormatChanged(EventTime eventTime, int trackType, Format format) {}
+
+  @Override
+  @Deprecated
+  public void onDecoderDisabled(
+      EventTime eventTime, int trackType, DecoderCounters decoderCounters) {}
+
+  @Override
+  public void onAudioEnabled(EventTime eventTime, DecoderCounters counters) {}
+
+  @Override
+  @Deprecated
+  public void onAudioDecoderInitialized(
+      EventTime eventTime, String decoderName, long initializationDurationMs) {}
+
+  @Override
+  @Deprecated
+  public void onAudioInputFormatChanged(EventTime eventTime, Format format) {}
+
+  @Override
+  public void onAudioInputFormatChanged(
+      EventTime eventTime,
+      Format format,
+      @Nullable DecoderReuseEvaluation decoderReuseEvaluation) {}
+
+  @Override
+  public void onAudioPositionAdvancing(EventTime eventTime, long playoutStartSystemTimeMs) {}
+
+  @Override
+  public void onAudioDecoderReleased(EventTime eventTime, String decoderName) {}
+
+  @Override
+  public void onAudioDisabled(EventTime eventTime, DecoderCounters counters) {}
+
+  @Override
+  public void onAudioSessionIdChanged(EventTime eventTime, int audioSessionId) {}
+
+  @Override
+  public void onSkipSilenceEnabledChanged(EventTime eventTime, boolean skipSilenceEnabled) {}
+
+  @Override
+  public void onAudioSinkError(EventTime eventTime, Exception audioSinkError) {}
+
+  @Override
+  public void onVideoEnabled(EventTime eventTime, DecoderCounters counters) {}
+
+  @Override
+  @Deprecated
+  public void onVideoDecoderInitialized(
+      EventTime eventTime, String decoderName, long initializationDurationMs) {}
+
+  @Override
+  public void onVideoInputFormatChanged(
+      EventTime eventTime,
+      Format format,
+      @Nullable DecoderReuseEvaluation decoderReuseEvaluation) {}
+
+  @Override
+  public void onDroppedVideoFrames(EventTime eventTime, int droppedFrames, long elapsedMs) {}
+
+  @Override
+  public void onVideoDecoderReleased(EventTime eventTime, String decoderName) {}
+
+  @Override
+  public void onVideoDisabled(EventTime eventTime, DecoderCounters counters) {}
+
+  @Override
+  public void onVideoFrameProcessingOffset(
+      EventTime eventTime, long totalProcessingOffsetUs, int frameCount) {}
+
+  @Override
+  @Deprecated
+  public void onDrmSessionAcquired(EventTime eventTime) {}
+
+  @Override
+  public void onDrmSessionReleased(EventTime eventTime) {}
+
+  @Override
+  public void onPlayerReleased(EventTime eventTime) {}
+
+  @Override
+  public void onEvents(Player player, Events events) {}
 }

--- a/MuxExoPlayer/src/r2_14_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_14_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -1,22 +1,42 @@
 package com.mux.stats.sdk.muxstats;
 
 import android.content.Context;
+import android.media.MediaCodec;
+import android.media.MediaCodec.CodecException;
+import android.os.Looper;
+import android.os.SystemClock;
+import android.view.Surface;
+import androidx.annotation.Nullable;
+import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.MediaItem;
+import com.google.android.exoplayer2.MediaMetadata;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
+import com.google.android.exoplayer2.Player.DiscontinuityReason;
+import com.google.android.exoplayer2.Player.PlaybackSuppressionReason;
+import com.google.android.exoplayer2.Player.TimelineChangeReason;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.Timeline;
 import com.google.android.exoplayer2.analytics.AnalyticsListener;
 import com.google.android.exoplayer2.audio.AudioAttributes;
+import com.google.android.exoplayer2.audio.AudioSink;
+import com.google.android.exoplayer2.decoder.DecoderCounters;
+import com.google.android.exoplayer2.decoder.DecoderException;
+import com.google.android.exoplayer2.decoder.DecoderReuseEvaluation;
+import com.google.android.exoplayer2.drm.DrmSession;
 import com.google.android.exoplayer2.mediacodec.MediaCodecRenderer;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 import com.google.android.exoplayer2.metadata.Metadata;
+import com.google.android.exoplayer2.metadata.MetadataOutput;
 import com.google.android.exoplayer2.source.LoadEventInfo;
 import com.google.android.exoplayer2.source.MediaLoadData;
 import com.google.android.exoplayer2.source.TrackGroupArray;
+import com.google.android.exoplayer2.text.Cue;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
+import com.google.android.exoplayer2.video.VideoDecoderOutputBufferRenderer;
 import com.mux.stats.sdk.core.CustomOptions;
 import com.google.android.exoplayer2.video.VideoSize;
 import com.mux.stats.sdk.core.model.CustomerData;
@@ -25,6 +45,7 @@ import com.mux.stats.sdk.core.model.CustomerVideoData;
 import com.mux.stats.sdk.core.model.CustomerViewData;
 import com.mux.stats.sdk.core.util.MuxLogger;
 import java.io.IOException;
+import java.util.List;
 
 public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsListener,
     Player.Listener {
@@ -451,4 +472,170 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
     bandwidthDispatcher.onTracksChanged(trackGroups);
     configurePlaybackHeadUpdateInterval();
   }
+
+  // Empty implementations of default methods from our interfaces
+  // This is to workaround https://github.com/google/ExoPlayer/issues/6801
+
+  @Override
+  @Deprecated
+  public void onPlayerStateChanged(
+      EventTime eventTime, boolean playWhenReady, @Player.State int playbackState) {}
+
+  @Override
+  public void onMediaItemTransition(
+      EventTime eventTime,
+      @Nullable MediaItem mediaItem,
+      @Player.MediaItemTransitionReason int reason) {}
+
+  @Override
+  public void onPositionDiscontinuity(
+      EventTime eventTime,
+      Player.PositionInfo oldPosition,
+      Player.PositionInfo newPosition,
+      @DiscontinuityReason int reason) {}
+
+  @Override
+  @Deprecated
+  public void onSeekProcessed(EventTime eventTime) {}
+
+  @Override
+  @Deprecated
+  public void onLoadingChanged(EventTime eventTime, boolean isLoading) {}
+
+  @Override
+  public void onStaticMetadataChanged(EventTime eventTime, List<Metadata> metadataList) {}
+
+  @Override
+  public void onMediaMetadataChanged(EventTime eventTime, MediaMetadata mediaMetadata) {}
+
+  @Override
+  public void onBandwidthEstimate(
+      EventTime eventTime, int totalLoadTimeMs, long totalBytesLoaded, long bitrateEstimate) {}
+
+  @Override
+  @Deprecated
+  public void onDecoderEnabled(
+      EventTime eventTime, int trackType, DecoderCounters decoderCounters) {}
+
+  @Override
+  @Deprecated
+  public void onDecoderInitialized(
+      EventTime eventTime, int trackType, String decoderName, long initializationDurationMs) {}
+
+  @Override
+  @Deprecated
+  public void onDecoderInputFormatChanged(EventTime eventTime, int trackType, Format format) {}
+
+  @Override
+  @Deprecated
+  public void onDecoderDisabled(
+      EventTime eventTime, int trackType, DecoderCounters decoderCounters) {}
+
+  @Override
+  public void onAudioEnabled(EventTime eventTime, DecoderCounters counters) {}
+
+  @Override
+  public void onAudioDecoderInitialized(
+      EventTime eventTime,
+      String decoderName,
+      long initializedTimestampMs,
+      long initializationDurationMs) {}
+
+  @Override
+  @Deprecated
+  public void onAudioDecoderInitialized(
+      EventTime eventTime, String decoderName, long initializationDurationMs) {}
+
+  @Override
+  @Deprecated
+  public void onAudioInputFormatChanged(EventTime eventTime, Format format) {}
+
+  @Override
+  public void onAudioInputFormatChanged(
+      EventTime eventTime,
+      Format format,
+      @Nullable DecoderReuseEvaluation decoderReuseEvaluation) {}
+
+  @Override
+  public void onAudioPositionAdvancing(EventTime eventTime, long playoutStartSystemTimeMs) {}
+
+  @Override
+  public void onAudioDecoderReleased(EventTime eventTime, String decoderName) {}
+
+  @Override
+  public void onAudioDisabled(EventTime eventTime, DecoderCounters counters) {}
+
+  @Override
+  public void onAudioSessionIdChanged(EventTime eventTime, int audioSessionId) {}
+
+  @Override
+  public void onSkipSilenceEnabledChanged(EventTime eventTime, boolean skipSilenceEnabled) {}
+
+  @Override
+  public void onAudioSinkError(EventTime eventTime, Exception audioSinkError) {}
+
+  @Override
+  public void onAudioCodecError(EventTime eventTime, Exception audioCodecError) {}
+
+  @Override
+  public void onVideoEnabled(EventTime eventTime, DecoderCounters counters) {}
+
+  @Override
+  public void onVideoDecoderInitialized(
+      EventTime eventTime,
+      String decoderName,
+      long initializedTimestampMs,
+      long initializationDurationMs) {}
+
+  @Override
+  @Deprecated
+  public void onVideoDecoderInitialized(
+      EventTime eventTime, String decoderName, long initializationDurationMs) {}
+
+  @Override
+  public void onVideoInputFormatChanged(
+      EventTime eventTime,
+      Format format,
+      @Nullable DecoderReuseEvaluation decoderReuseEvaluation) {}
+
+  @Override
+  public void onDroppedVideoFrames(EventTime eventTime, int droppedFrames, long elapsedMs) {}
+
+  @Override
+  public void onVideoDecoderReleased(EventTime eventTime, String decoderName) {}
+
+  @Override
+  public void onVideoDisabled(EventTime eventTime, DecoderCounters counters) {}
+
+  @Override
+  public void onVideoFrameProcessingOffset(
+      EventTime eventTime, long totalProcessingOffsetUs, int frameCount) {}
+
+  @Override
+  public void onVideoCodecError(EventTime eventTime, Exception videoCodecError) {}
+
+  @Override
+  @Deprecated
+  public void onVideoSizeChanged(
+      EventTime eventTime,
+      int width,
+      int height,
+      int unappliedRotationDegrees,
+      float pixelWidthHeightRatio) {}
+
+  @Override
+  @Deprecated
+  public void onDrmSessionAcquired(EventTime eventTime) {}
+
+  @Override
+  public void onDrmSessionAcquired(EventTime eventTime, @DrmSession.State int state) {}
+
+  @Override
+  public void onDrmSessionReleased(EventTime eventTime) {}
+
+  @Override
+  public void onPlayerReleased(EventTime eventTime) {}
+
+  @Override
+  public void onEvents(Player player, Events events) {}
 }

--- a/MuxExoPlayer/src/r2_9_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_9_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -480,4 +480,14 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
   @Override
   public void onSeekProcessed() {
   }
+
+  // Empty implementations of default methods from our interfaces
+  // This is to workaround https://github.com/google/ExoPlayer/issues/6801
+
+  @Override
+  @Deprecated
+  public void onDrmSessionAcquired(EventTime eventTime) {}
+
+  @Override
+  public void onDrmSessionReleased(EventTime eventTime) {}
 }


### PR DESCRIPTION
Accessing a method on the Exoplayer AnalyticsListener interface which we did not implement (because it has a default implementation) causes AbstractMethodErrors at runtime for downstream consumers via the maven repository.

The underlying reasons for this are:
1. The pom for the artifact doesn't mention exoplayer
2. That breaks the Java8 language hackery google implemented in the android build system which tries to isolate bits of the code as much as possible, such that the exoplayer imported by the application is not actually linked with the mux-stats-exoplayer-sdk during the compilation step (i.e. it does not, by default, load all the stuff in the classpath and consider it as a whole), so the default implementations of the methods do not get magically injected. (That behaviour can be altered by setting android.enableDexingArtifactTransform=false in gradle.properties in the consuming application).

So why not mention exoplayer in the pom? We have multiple artifacts, each for a different exoplayer, and thus different conflicting dependencies. Unfortunately a single gradle incantation won't publish multiple artifact IDs. Resolving this "properly" such that the pom declares the exoplayer version in use would require quite a big modification to the build process, with the two major headaches being what should we be publishing then and how to run gradle? I think the answers are:

1. We will need a totally different artifact per exoplayer version we support, and not merely a different classifier. The pom can then safely declare the exoplayer dependency.
2. We will need to run gradle from our build scripts separately for each artifact and not rely on it to do any of this

Curiously we are not alone in this: https://github.com/google/ExoPlayer/issues/6801 Somehow there is someone in there saying the mux library was causing a problem of this kind back in early 2020.