### PR TITLE
Maven fixes

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -13,90 +13,90 @@ steps:
           - "MuxExoPlayer/buildout/reports/*/*.*"
           - "automatedtests/buildout/outputs/apk/androidTest/**/*.apk"
           - "automatedtests/buildout/outputs/apk/*/debug/automatedtests-*-debug.apk"
-#- wait
-#- agents: [dind=true,queue=beta]
-#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-#  label: Test Exoplayer r2_9_6 on Pixel device
-#  retry:
-#    automatic:
-#      - exit_status: 1
-#        limit: 2
-#  plugins:
-#    - artifacts#v1.3.0:
-#        download:
-#          - "automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk"
-#          - "automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk"
-#- wait
-#- agents: [dind=true,queue=beta]
-#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-#  label: Test Exoplayer r2_10_6 on Pixel device
-#  retry:
-#    automatic:
-#      - exit_status: 1
-#        limit: 2
-#  plugins:
-#    - artifacts#v1.3.0:
-#        download:
-#          - "automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk"
-#          - "automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk"
-#- wait
-#- agents: [dind=true,queue=beta]
-#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-#  label: Test Exoplayer r2_11_1 on Pixel device
-#  retry:
-#    automatic:
-#      - exit_status: 1
-#        limit: 2
-#  plugins:
-#    - artifacts#v1.3.0:
-#        download:
-#          - "automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk"
-#          - "automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk"
-#- wait
-#- agents: [dind=true,queue=beta]
-#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-#  label: Test Exoplayer r2_12_1 on Pixel device
-#  retry:
-#    automatic:
-#      - exit_status: 1
-#        limit: 2
-#  plugins:
-#    - artifacts#v1.3.0:
-#        download:
-#          - "automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk"
-#          - "automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk"
-#- wait
-#- agents: [dind=true,queue=beta]
-#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-#  label: Test Exoplayer r2_13_1 on Pixel device
-#  retry:
-#    automatic:
-#      - exit_status: 1
-#        limit: 2
-#  plugins:
-#    - artifacts#v1.3.0:
-#        download:
-#          - "automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk"
-#          - "automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk"
-#- wait
-#- agents: [dind=true,queue=beta]
-#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-#  label: Test Exoplayer r2_14_1 on Pixel device
-#  retry:
-#    automatic:
-#      - exit_status: 1
-#        limit: 2
-#  plugins:
-#    - artifacts#v1.3.0:
-#        download:
-#          - "automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk"
-#          - "automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk"
-#- wait
-#- block: ":rocket: Deploy and release!"
-#  blocked_state: failed
-#  branches: "master"
-#- wait
-#- agents: [ dind=true,queue=beta ]
-#  command: ./.buildkite/deploy.sh
-#  label: Deploy artifacts to release maven if it all worked
-#  branches: "master"
+- wait
+- agents: [dind=true,queue=beta]
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_9_6 on Pixel device
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk"
+- wait
+- agents: [dind=true,queue=beta]
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_10_6 on Pixel device
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk"
+- wait
+- agents: [dind=true,queue=beta]
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_11_1 on Pixel device
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk"
+- wait
+- agents: [dind=true,queue=beta]
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_12_1 on Pixel device
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk"
+- wait
+- agents: [dind=true,queue=beta]
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_13_1 on Pixel device
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk"
+- wait
+- agents: [dind=true,queue=beta]
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_14_1 on Pixel device
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk"
+- wait
+- block: ":rocket: Deploy and release!"
+  blocked_state: failed
+  branches: "master"
+- wait
+- agents: [ dind=true,queue=beta ]
+  command: ./.buildkite/deploy.sh
+  label: Deploy artifacts to release maven if it all worked
+  branches: "master"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -7,8 +7,8 @@ steps:
   plugins:
     - artifacts#v1.3.0:
         upload:
-          - "MuxExoPlayer/buildout/outputs/artifacts/*.aar"
-          - "MuxExoPlayer/buildout/outputs/artifacts/*.txt"
+          - "MuxExoPlayer/buildout/outputs/aar/*.aar"
+          - "MuxExoPlayer/buildout/outputs/mapping/*/*.txt"
           - "MuxExoPlayer/buildout/outputs/version-*"
           - "MuxExoPlayer/buildout/reports/*/*.*"
           - "automatedtests/buildout/outputs/apk/androidTest/**/*.apk"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -13,90 +13,90 @@ steps:
           - "MuxExoPlayer/buildout/reports/*/*.*"
           - "automatedtests/buildout/outputs/apk/androidTest/**/*.apk"
           - "automatedtests/buildout/outputs/apk/*/debug/automatedtests-*-debug.apk"
-- wait
-- agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_9_6 on Pixel device
-  retry:
-    automatic:
-      - exit_status: 1
-        limit: 2
-  plugins:
-    - artifacts#v1.3.0:
-        download:
-          - "automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk"
-- wait
-- agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_10_6 on Pixel device
-  retry:
-    automatic:
-      - exit_status: 1
-        limit: 2
-  plugins:
-    - artifacts#v1.3.0:
-        download:
-          - "automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk"
-- wait
-- agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_11_1 on Pixel device
-  retry:
-    automatic:
-      - exit_status: 1
-        limit: 2
-  plugins:
-    - artifacts#v1.3.0:
-        download:
-          - "automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk"
-- wait
-- agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_12_1 on Pixel device
-  retry:
-    automatic:
-      - exit_status: 1
-        limit: 2
-  plugins:
-    - artifacts#v1.3.0:
-        download:
-          - "automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk"
-- wait
-- agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_13_1 on Pixel device
-  retry:
-    automatic:
-      - exit_status: 1
-        limit: 2
-  plugins:
-    - artifacts#v1.3.0:
-        download:
-          - "automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk"
-- wait
-- agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_14_1 on Pixel device
-  retry:
-    automatic:
-      - exit_status: 1
-        limit: 2
-  plugins:
-    - artifacts#v1.3.0:
-        download:
-          - "automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk"
-- wait
-- block: ":rocket: Deploy and release!"
-  blocked_state: failed
-  branches: "master"
-- wait
-- agents: [ dind=true,queue=beta ]
-  command: ./.buildkite/deploy.sh
-  label: Deploy artifacts to release maven if it all worked
-  branches: "master"
+#- wait
+#- agents: [dind=true,queue=beta]
+#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+#  label: Test Exoplayer r2_9_6 on Pixel device
+#  retry:
+#    automatic:
+#      - exit_status: 1
+#        limit: 2
+#  plugins:
+#    - artifacts#v1.3.0:
+#        download:
+#          - "automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk"
+#          - "automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk"
+#- wait
+#- agents: [dind=true,queue=beta]
+#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+#  label: Test Exoplayer r2_10_6 on Pixel device
+#  retry:
+#    automatic:
+#      - exit_status: 1
+#        limit: 2
+#  plugins:
+#    - artifacts#v1.3.0:
+#        download:
+#          - "automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk"
+#          - "automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk"
+#- wait
+#- agents: [dind=true,queue=beta]
+#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+#  label: Test Exoplayer r2_11_1 on Pixel device
+#  retry:
+#    automatic:
+#      - exit_status: 1
+#        limit: 2
+#  plugins:
+#    - artifacts#v1.3.0:
+#        download:
+#          - "automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk"
+#          - "automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk"
+#- wait
+#- agents: [dind=true,queue=beta]
+#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+#  label: Test Exoplayer r2_12_1 on Pixel device
+#  retry:
+#    automatic:
+#      - exit_status: 1
+#        limit: 2
+#  plugins:
+#    - artifacts#v1.3.0:
+#        download:
+#          - "automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk"
+#          - "automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk"
+#- wait
+#- agents: [dind=true,queue=beta]
+#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+#  label: Test Exoplayer r2_13_1 on Pixel device
+#  retry:
+#    automatic:
+#      - exit_status: 1
+#        limit: 2
+#  plugins:
+#    - artifacts#v1.3.0:
+#        download:
+#          - "automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk"
+#          - "automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk"
+#- wait
+#- agents: [dind=true,queue=beta]
+#  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+#  label: Test Exoplayer r2_14_1 on Pixel device
+#  retry:
+#    automatic:
+#      - exit_status: 1
+#        limit: 2
+#  plugins:
+#    - artifacts#v1.3.0:
+#        download:
+#          - "automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk"
+#          - "automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk"
+#- wait
+#- block: ":rocket: Deploy and release!"
+#  blocked_state: failed
+#  branches: "master"
+#- wait
+#- agents: [ dind=true,queue=beta ]
+#  command: ./.buildkite/deploy.sh
+#  label: Deploy artifacts to release maven if it all worked
+#  branches: "master"

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -12,16 +12,4 @@ docker run -it -v --rm  \
     -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
     -w /data \
     muxinc/mux-exoplayer:20210915 \
-    bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:artifactoryPublish"
-
-docker run -it -v --rm  \
-    -v $(pwd):/data \
-    -e BUILDKITE_BRANCH="$BUILDKITE_BRANCH" \
-    -e ORG_GRADLE_PROJECT_signingKeyId="$ORG_GRADLE_PROJECT_signingKeyId" \
-    -e ORG_GRADLE_PROJECT_signingPassword="$ORG_GRADLE_PROJECT_signingPassword" \
-    -e ORG_GRADLE_PROJECT_signingKey="$ORG_GRADLE_PROJECT_signingKey" \
-    -e ORG_GRADLE_PROJECT_artifactory_user=$ORG_GRADLE_PROJECT_artifactory_user \
-    -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
-    -w /data \
-    muxinc/mux-exoplayer:20210915 \
-    bash -c "./gradlew --info assemble automatedtests:assembleAndroidTest"
+    bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:artifactoryPublish automatedtests:assembleAndroidTest"

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -12,4 +12,4 @@ docker run -it -v --rm  \
     -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
     -w /data \
     muxinc/mux-exoplayer:20210915 \
-    bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:assemble MuxExoPlayer:artifactoryPublish automatedtests:assembleAndroidTest"
+    bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:assemble MuxExoPlayer:artifactoryPublish automatedtests:assemble automatedtests:assembleAndroidTest"

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -12,19 +12,7 @@ docker run -it -v --rm  \
     -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
     -w /data \
     muxinc/mux-exoplayer:20210915 \
-    bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:build"
-
-docker run -it -v --rm  \
-    -v $(pwd):/data \
-    -e BUILDKITE_BRANCH="$BUILDKITE_BRANCH" \
-    -e ORG_GRADLE_PROJECT_signingKeyId="$ORG_GRADLE_PROJECT_signingKeyId" \
-    -e ORG_GRADLE_PROJECT_signingPassword="$ORG_GRADLE_PROJECT_signingPassword" \
-    -e ORG_GRADLE_PROJECT_signingKey="$ORG_GRADLE_PROJECT_signingKey" \
-    -e ORG_GRADLE_PROJECT_artifactory_user=$ORG_GRADLE_PROJECT_artifactory_user \
-    -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
-    -w /data \
-    muxinc/mux-exoplayer:20210915 \
-    bash -c "./gradlew --info MuxExoPlayer:publish MuxExoPlayer:artifactoryPublish"
+    bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:artifactoryPublish"
 
 docker run -it -v --rm  \
     -v $(pwd):/data \

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -12,4 +12,4 @@ docker run -it -v --rm  \
     -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
     -w /data \
     muxinc/mux-exoplayer:20210915 \
-    bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:artifactoryPublish automatedtests:assembleAndroidTest"
+    bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:assemble MuxExoPlayer:artifactoryPublish automatedtests:assembleAndroidTest"

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -12,4 +12,16 @@ docker run -it -v --rm  \
     -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
     -w /data \
     muxinc/mux-exoplayer:20210915 \
-    bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:assemble MuxExoPlayer:artifactoryPublish automatedtests:assemble automatedtests:assembleAndroidTest"
+    bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:assemble MuxExoPlayer:artifactoryPublish"
+
+docker run -it -v --rm  \
+    -v $(pwd):/data \
+    -e BUILDKITE_BRANCH="$BUILDKITE_BRANCH" \
+    -e ORG_GRADLE_PROJECT_signingKeyId="$ORG_GRADLE_PROJECT_signingKeyId" \
+    -e ORG_GRADLE_PROJECT_signingPassword="$ORG_GRADLE_PROJECT_signingPassword" \
+    -e ORG_GRADLE_PROJECT_signingKey="$ORG_GRADLE_PROJECT_signingKey" \
+    -e ORG_GRADLE_PROJECT_artifactory_user=$ORG_GRADLE_PROJECT_artifactory_user \
+    -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
+    -w /data \
+    muxinc/mux-exoplayer:20210915 \
+    bash -c "./gradlew --info automatedtests:assemble automatedtests:assembleAndroidTest"

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -207,3 +207,53 @@ dependencies {
         embed muxCoreImport
     }
 }
+
+afterEvaluate {
+    publishing {
+        publications {
+            // Note each publication needs to be mentioned in the _project_ build.gradle too
+            // Would be nice to not copy/paste all this
+            r2_9_6Release(MavenPublication) {
+                from components.r2_9_6Release
+                groupId = "com.mux.stats.sdk.muxstats"
+                artifactId = "MuxExoPlayer_r2_9_6"
+                version = project.ext.versionName
+            }
+
+            r2_10_6Release(MavenPublication) {
+                from components.r2_10_6Release
+                groupId = "com.mux.stats.sdk.muxstats"
+                artifactId = "MuxExoPlayer_r2_10_6"
+                version = project.ext.versionName
+            }
+
+            r2_11_1Release(MavenPublication) {
+                from components.r2_11_1Release
+                groupId = "com.mux.stats.sdk.muxstats"
+                artifactId = "MuxExoPlayer_r2_11_1"
+                version = project.ext.versionName
+            }
+
+            r2_12_1Release(MavenPublication) {
+                from components.r2_12_1Release
+                groupId = "com.mux.stats.sdk.muxstats"
+                artifactId = "MuxExoPlayer_r2_12_1"
+                version = project.ext.versionName
+            }
+
+            r2_13_1Release(MavenPublication) {
+                from components.r2_13_1Release
+                groupId = "com.mux.stats.sdk.muxstats"
+                artifactId = "MuxExoPlayer_r2_13_1"
+                version = project.ext.versionName
+            }
+
+            r2_14_1Release(MavenPublication) {
+                from components.r2_14_1Release
+                groupId = "com.mux.stats.sdk.muxstats"
+                artifactId = "MuxExoPlayer_r2_14_1"
+                version = project.ext.versionName
+            }
+        }
+    }
+}

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -212,7 +212,7 @@ afterEvaluate {
     publishing {
         publications {
             // Note each publication needs to be mentioned in the _project_ build.gradle too
-            // Would be nice to not copy/paste all this
+            // Would be nice to not copy/paste all this - possible approach https://stackoverflow.com/a/66349023
             r2_9_6Release(MavenPublication) {
                 from components.r2_9_6Release
                 groupId = "com.mux.stats.sdk.muxstats"

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -114,12 +114,12 @@ dependencies {
     if(project.ext.inLocalDevMode) {
         implementation project(':MuxExoPlayer')
     } else {
-        r2_9_6Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.9.6@aar'
-        r2_10_6Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.10.6@aar'
-        r2_11_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.11.1@aar'
-        r2_12_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.12.1@aar'
-        r2_13_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.13.1@aar'
-        r2_14_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.14.1@aar'
+        r2_9_6Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_9_6:'+project.ext.versionName
+        r2_10_6Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_10_6:'+project.ext.versionName
+        r2_11_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_11_1:'+project.ext.versionName
+        r2_12_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_12_1:'+project.ext.versionName
+        r2_13_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_13_1:'+project.ext.versionName
+        r2_14_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_14_1:'+project.ext.versionName
     }
 
     r2_9_6Api 'com.google.android.exoplayer:exoplayer:2.9.6'

--- a/build.gradle
+++ b/build.gradle
@@ -179,18 +179,27 @@ artifactory {
     }
 }
 
+def deployVariant(variant) {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'curl', '-u', "${artifactory_user}:${artifactory_password}", '-X', "POST", "https://muxinc.jfrog.io/artifactory/api/copy/default-maven-local/com/mux/stats/sdk/muxstats/MuxExoPlayer/MuxExoplayer_" +variant+"-" + packageVersionName + "?to=/default-maven-release-local/com/mux/stats/sdk/muxstats/MuxExoPlayer/MuxExoplayer_" +variant+"-" + packageVersionName
+        standardOutput = stdout
+    }
+    def msg = stdout.toString()
+    println(msg)
+}
+
 task muxReleaseDeploy {
     doLast {
         if(isAReleaseBuild) {
             println("Deploying from local maven to release maven")
 
-            def stdout = new ByteArrayOutputStream()
-            exec {
-                commandLine 'curl', '-u', "${artifactory_user}:${artifactory_password}", '-X', "POST", "https://muxinc.jfrog.io/artifactory/api/copy/default-maven-local/com/mux/stats/sdk/muxstats/MuxExoPlayer/" + packageVersionName + "?to=/default-maven-release-local/com/mux/stats/sdk/muxstats/MuxExoPlayer/" + packageVersionName
-                standardOutput = stdout
-            }
-            def msg = stdout.toString()
-            println(msg)
+            deployVariant("r2_9_6")
+            deployVariant("r2_10_6")
+            deployVariant("r2_11_1")
+            deployVariant("r2_12_1")
+            deployVariant("r2_13_1")
+            deployVariant("r2_14_1")
 
             println("Release deployment complete")
         } else {

--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,7 @@ artifactory {
     }
 }
 
+// TODO fix this by LOOKING AT THE ACTUAL PATHS IN JFROG!?!??!
 def deployVariant(variant) {
     def stdout = new ByteArrayOutputStream()
     exec {

--- a/build.gradle
+++ b/build.gradle
@@ -150,24 +150,37 @@ allprojects {
     }
 }
 
+task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+    archiveClassifier.set('javadoc')
+    from androidJavadocs.destinationDir
+}
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+}
+
 afterEvaluate {
     project('MuxExoPlayer') {
-//        artifactoryPublish.dependsOn('publish')
         publishing {
             publications {
+                // Applies the component for the release build variant.
+                from components.release
+
+                // Adds javadocs and sources as separate jars.
+                artifact androidJavadocsJar
+                artifact androidSourcesJar
+
+                artifact(sourceJar)
+                artifact("${buildDir}/outputs/artifacts/${fileDetails.name}") {
+                    classifier ${variant.getFlavorName()}
+                    version = packageVersionName
+                }
+
                 mavenJava(MavenPublication) {
                     groupId = "com.mux.stats.sdk.muxstats"
-
-                    def outDirTree = fileTree(dir: "${buildDir}/outputs/artifacts/", exclude: ['**/*.txt'])
-                    outDirTree.visit { fileDetails ->
-                        def flavorName = fileDetails.name.replaceAll("mux-", "").replaceAll(".aar", "")
-                        println "=== Publishing >>>>> ${fileDetails.name}, flavor: ${flavorName}, version: ${packageVersionName}"
-
-                        artifact("${buildDir}/outputs/artifacts/${fileDetails.name}") {
-                            classifier flavorName
-                            version = packageVersionName
-                        }
-                    }
+                    artifactId = "exoplayer"+${variant.getFlavorName()}
+                    version = packageVersionName
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -150,43 +150,6 @@ allprojects {
     }
 }
 
-task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-    archiveClassifier.set('javadoc')
-    from androidJavadocs.destinationDir
-}
-
-task androidSourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-    from android.sourceSets.main.java.srcDirs
-}
-
-afterEvaluate {
-    project('MuxExoPlayer') {
-        publishing {
-            publications {
-                // Applies the component for the release build variant.
-                from components.release
-
-                // Adds javadocs and sources as separate jars.
-                artifact androidJavadocsJar
-                artifact androidSourcesJar
-
-                artifact(sourceJar)
-                artifact("${buildDir}/outputs/artifacts/${fileDetails.name}") {
-                    classifier ${variant.getFlavorName()}
-                    version = packageVersionName
-                }
-
-                mavenJava(MavenPublication) {
-                    groupId = "com.mux.stats.sdk.muxstats"
-                    artifactId = "exoplayer"+${variant.getFlavorName()}
-                    version = packageVersionName
-                }
-            }
-        }
-    }
-}
-
 artifactory {
     contextUrl = "https://muxinc.jfrog.io/artifactory/"
     publish {
@@ -198,6 +161,12 @@ artifactory {
         }
         defaults {
             publications ('mavenJava')
+            publications ('r2_9_6Release')
+            publications ('r2_10_6Release')
+            publications ('r2_11_1Release')
+            publications ('r2_12_1Release')
+            publications ('r2_13_1Release')
+            publications ('r2_14_1Release')
         }
     }
     resolve {

--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,8 @@ artifactory {
         }
         defaults {
             publications ('mavenJava')
+
+            // Need to list all the different variants here and in the deploy section below
             publications ('r2_9_6Release')
             publications ('r2_10_6Release')
             publications ('r2_11_1Release')
@@ -179,11 +181,10 @@ artifactory {
     }
 }
 
-// TODO fix this by LOOKING AT THE ACTUAL PATHS IN JFROG!?!??!
 def deployVariant(variant) {
     def stdout = new ByteArrayOutputStream()
     exec {
-        commandLine 'curl', '-u', "${artifactory_user}:${artifactory_password}", '-X', "POST", "https://muxinc.jfrog.io/artifactory/api/copy/default-maven-local/com/mux/stats/sdk/muxstats/MuxExoPlayer/MuxExoplayer_" +variant+"-" + packageVersionName + "?to=/default-maven-release-local/com/mux/stats/sdk/muxstats/MuxExoPlayer/MuxExoplayer_" +variant+"-" + packageVersionName
+        commandLine 'curl', '-u', "${artifactory_user}:${artifactory_password}", '-X', "POST", "https://muxinc.jfrog.io/artifactory/api/copy/default-maven-local/com/mux/stats/sdk/muxstats/MuxExoPlayer_" +variant+"/" + packageVersionName + "?to=/default-maven-release-local/com/mux/stats/sdk/muxstats/MuxExoPlayer_" +variant+"/" + packageVersionName
         standardOutput = stdout
     }
     def msg = stdout.toString()

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -212,17 +212,17 @@ dependencies {
         r2_14_1Api 'com.google.android.exoplayer:exoplayer:2.14.1'
         r2_14_1_adsApi 'com.google.android.exoplayer:exoplayer:2.14.1'
 
-        r2_9_6Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.9.6@aar'
-        r2_9_6_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.9.6@aar'
-        r2_10_6Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.10.6@aar'
-        r2_10_6_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.10.6@aar'
-        r2_11_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.11.1@aar'
-        r2_11_1_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.11.1@aar'
-        r2_12_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.12.1@aar'
-        r2_12_1_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.12.1@aar'
-        r2_13_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.13.1@aar'
-        r2_13_1_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.13.1@aar'
-        r2_14_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.14.1@aar'
-        r2_14_1_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer:'+project.ext.versionName+':r2.14.1@aar'
+        r2_9_6Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_9_6:'+project.ext.versionName
+        r2_9_6_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_9_6:'+project.ext.versionName
+        r2_10_6Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_10_6:'+project.ext.versionName
+        r2_10_6_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_10_6:'+project.ext.versionName
+        r2_11_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_11_1:'+project.ext.versionName
+        r2_11_1_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_11_1:'+project.ext.versionName
+        r2_12_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_12_1:'+project.ext.versionName
+        r2_12_1_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_12_1:'+project.ext.versionName
+        r2_13_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_13_1:'+project.ext.versionName
+        r2_13_1_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_13_1:'+project.ext.versionName
+        r2_14_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_14_1:'+project.ext.versionName
+        r2_14_1_adsApi 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_14_1:'+project.ext.versionName
     }
 }


### PR DESCRIPTION
We had problems with downstream consumers of the library getting AbstractMethodExceptions. The proper way to resolve this is to improve our dependency tracking and exposing it through the maven and gradle files in artifactory.

This actually does that, a result of thinking about how a similar problem was fixed in MuxCore. It does mean we need to slightly alter the string people use to import the dependency, but if anything it's actually easier than before. It's now:
```api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_14_1:v2.x.x'```

This creates separate artifacts (each with their own pom etc.) on jfrog.

Essentially our problem losing all the dependency info (both on MuxCore and here) is the copy file step followed by creating an artifact from the file, which seems to cause gradle to lose all the metadata about the process that created the artifact. If you jump through the hoops to refer to the artifact by reference (such as the brilliantly undiscoverable "from components.r2_9_6Release") as opposed to by filepath then it works and the dependency info is output correctly. 

There appear to be ways to do this which reduce the copy/paste such as https://stackoverflow.com/a/66349023 , however, there is a need for expediency, and as mentioned there the risk of losing dependency info as well.