### PR TITLE
Nb build cleanup experiment

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -15,8 +15,8 @@ steps:
           - "automatedtests/buildout/outputs/apk/*/debug/automatedtests-*-debug.apk"
 - wait
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_9_6 on Pixel device
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_15_1/debug/automatedtests-r2_15_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_15_1/debug/automatedtests-r2_15_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_15_1 on Pixel device
   retry:
     automatic:
       - exit_status: 1
@@ -24,60 +24,8 @@ steps:
   plugins:
     - artifacts#v1.3.0:
         download:
-          - "automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk"
-- wait
-- agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_10_6 on Pixel device
-  retry:
-    automatic:
-      - exit_status: 1
-        limit: 2
-  plugins:
-    - artifacts#v1.3.0:
-        download:
-          - "automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk"
-- wait
-- agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_11_1 on Pixel device
-  retry:
-    automatic:
-      - exit_status: 1
-        limit: 2
-  plugins:
-    - artifacts#v1.3.0:
-        download:
-          - "automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk"
-- wait
-- agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_12_1 on Pixel device
-  retry:
-    automatic:
-      - exit_status: 1
-        limit: 2
-  plugins:
-    - artifacts#v1.3.0:
-        download:
-          - "automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk"
-- wait
-- agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_13_1 on Pixel device
-  retry:
-    automatic:
-      - exit_status: 1
-        limit: 2
-  plugins:
-    - artifacts#v1.3.0:
-        download:
-          - "automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk"
+          - "automatedtests/buildout/outputs/apk/r2_15_1/debug/automatedtests-r2_15_1-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_15_1/debug/automatedtests-r2_15_1-debug-androidTest.apk"
 - wait
 - agents: [dind=true,queue=beta]
   command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
@@ -93,8 +41,8 @@ steps:
           - "automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk"
 - wait
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_15_1/debug/automatedtests-r2_15_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_15_1/debug/automatedtests-r2_15_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
-  label: Test Exoplayer r2_15_1 on Pixel device
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_13_1 on Pixel device
   retry:
     automatic:
       - exit_status: 1
@@ -102,8 +50,64 @@ steps:
   plugins:
     - artifacts#v1.3.0:
         download:
-          - "automatedtests/buildout/outputs/apk/r2_15_1/debug/automatedtests-r2_15_1-debug.apk"
-          - "automatedtests/buildout/outputs/apk/androidTest/r2_15_1/debug/automatedtests-r2_15_1-debug-androidTest.apk"
+          - "automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk"
+- wait
+- agents: [dind=true,queue=beta]
+  branches: "master"
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_12_1 on Pixel device
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk"
+- wait
+- agents: [dind=true,queue=beta]
+  branches: "master"
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_11_1 on Pixel device
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk"
+- wait
+- agents: [dind=true,queue=beta]
+  branches: "master"
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_10_6 on Pixel device
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk"
+- wait
+- agents: [dind=true,queue=beta]
+  branches: "master"
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  label: Test Exoplayer r2_9_6 on Pixel device
+  retry:
+    automatic:
+      - exit_status: 1
+        limit: 2
+  plugins:
+    - artifacts#v1.3.0:
+        download:
+          - "automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk"
+          - "automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk"
 - wait
 - block: ":rocket: Deploy and release!"
   blocked_state: failed

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -15,7 +15,7 @@ steps:
           - "automatedtests/buildout/outputs/apk/*/debug/automatedtests-*-debug.apk"
 - wait
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_15_1/debug/automatedtests-r2_15_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_15_1/debug/automatedtests-r2_15_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_15_1/debug/automatedtests-r2_15_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_15_1/debug/automatedtests-r2_15_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.73.1
   label: Test Exoplayer r2_15_1 on Pixel device
   retry:
     automatic:
@@ -28,7 +28,7 @@ steps:
           - "automatedtests/buildout/outputs/apk/androidTest/r2_15_1/debug/automatedtests-r2_15_1-debug-androidTest.apk"
 - wait
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_14_1/debug/automatedtests-r2_14_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.73.1
   label: Test Exoplayer r2_14_1 on Pixel device
   retry:
     automatic:
@@ -41,7 +41,7 @@ steps:
           - "automatedtests/buildout/outputs/apk/androidTest/r2_14_1/debug/automatedtests-r2_14_1-debug-androidTest.apk"
 - wait
 - agents: [dind=true,queue=beta]
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_13_1/debug/automatedtests-r2_13_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_13_1/debug/automatedtests-r2_13_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.73.1
   label: Test Exoplayer r2_13_1 on Pixel device
   retry:
     automatic:
@@ -55,7 +55,7 @@ steps:
 - wait
 - agents: [dind=true,queue=beta]
   branches: "master"
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_12_1/debug/automatedtests-r2_12_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_12_1/debug/automatedtests-r2_12_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.73.1
   label: Test Exoplayer r2_12_1 on Pixel device
   retry:
     automatic:
@@ -69,7 +69,7 @@ steps:
 - wait
 - agents: [dind=true,queue=beta]
   branches: "master"
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_11_1/debug/automatedtests-r2_11_1-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_11_1/debug/automatedtests-r2_11_1-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.73.1
   label: Test Exoplayer r2_11_1 on Pixel device
   retry:
     automatic:
@@ -83,7 +83,7 @@ steps:
 - wait
 - agents: [dind=true,queue=beta]
   branches: "master"
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_10_6/debug/automatedtests-r2_10_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_10_6/debug/automatedtests-r2_10_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.73.1
   label: Test Exoplayer r2_10_6 on Pixel device
   retry:
     automatic:
@@ -97,7 +97,7 @@ steps:
 - wait
 - agents: [dind=true,queue=beta]
   branches: "master"
-  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.54.0-22f296b
+  command: docker run --rm -v $(pwd):/data -e BUILD_LABEL="$SAUCECTL_LABEL" -e TEST_APK=/data/automatedtests/buildout/outputs/apk/androidTest/r2_9_6/debug/automatedtests-r2_9_6-debug-androidTest.apk -e APP_APK=/data/automatedtests/buildout/outputs/apk/r2_9_6/debug/automatedtests-r2_9_6-debug.apk -e TEST_DEVICES='Google Pixel[ 345]*' -e SAUCE_USERNAME='mux-sauce' -e SAUCE_ACCESS_KEY=$SAUCE_ACCESS_KEY muxinc/saucectl-runner:0.73.1
   label: Test Exoplayer r2_9_6 on Pixel device
   retry:
     automatic:

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -197,6 +197,8 @@ dependencies {
     }
 }
 
+// Create a publication declaration for each flavor
+// Each published flavor still needs to be listed in the _project_ build.gradle
 afterEvaluate {
     android.libraryVariants.each { variant ->
         def matcher = variant.name =~ /(r\d+_\d+_\d+)Release.*/

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -55,50 +55,6 @@ android {
         // https://github.com/google/ExoPlayer/issues/4234
         lintConfig file("../checker-framework-lint.xml")
     }
-    sourceSets {
-        r2_9_6 {
-            java.srcDirs = ['./src/r2_9_6/java']
-        }
-        r2_9_6_ads {
-            java.srcDirs = ['./src/r2_9_6/java']
-        }
-        r2_10_6 {
-            java.srcDirs = ['./src/r2_10_6/java']
-        }
-        r2_10_6_ads {
-            java.srcDirs = ['./src/r2_10_6/java']
-        }
-        r2_11_1 {
-            java.srcDirs = ['./src/r2_11_1/java']
-        }
-        r2_11_1_ads {
-            java.srcDirs = ['./src/r2_11_1/java']
-        }
-        r2_12_1 {
-            java.srcDirs = ['./src/r2_12_1/java']
-        }
-        r2_12_1_ads {
-            java.srcDirs = ['./src/r2_12_1/java']
-        }
-        r2_13_1 {
-            java.srcDirs = ['./src/r2_13_1/java']
-        }
-        r2_13_1_ads {
-            java.srcDirs = ['./src/r2_13_1/java']
-        }
-        r2_14_1 {
-            java.srcDirs = ['./src/r2_14_1/java']
-        }
-        r2_14_1_ads {
-            java.srcDirs = ['./src/r2_14_1/java']
-        }
-        r2_15_1 {
-            java.srcDirs = ['./src/r2_15_1/java']
-        }
-        r2_15_1_ads {
-            java.srcDirs = ['./src/r2_15_1/java']
-        }
-    }
 
     flavorDimensions 'api'
 
@@ -144,6 +100,18 @@ android {
         }
         r2_15_1_ads {
             dimension 'api'
+        }
+    }
+
+    // Attach the java src directory relevant for each flavor created
+    afterEvaluate {
+        android.libraryVariants.each { variant ->
+            def matcher = variant.name =~ /(r\d+_\d+_\d+).*/
+            if(matcher.find()) {
+                def strippedExoPlayerVersion = matcher.group(1)
+                def sourceSet = sourceSets.findByName(variant.name)
+                sourceSet.java.srcDirs = ['./src/' + strippedExoPlayerVersion + '/java']
+            }
         }
     }
 
@@ -230,57 +198,16 @@ dependencies {
 }
 
 afterEvaluate {
-    publishing {
-        publications {
-            // Note each publication needs to be mentioned in the _project_ build.gradle too
-            // Would be nice to not copy/paste all this - possible approach https://stackoverflow.com/a/66349023
-            r2_9_6Release(MavenPublication) {
-                from components.r2_9_6Release
-                groupId = "com.mux.stats.sdk.muxstats"
-                artifactId = "MuxExoPlayer_r2_9_6"
-                version = project.ext.versionName
-            }
+    android.libraryVariants.each { variant ->
+        def matcher = variant.name =~ /(r\d+_\d+_\d+)Release.*/
+        if(matcher.find()) {
+            def strippedExoPlayerVersion = matcher.group(1)
 
-            r2_10_6Release(MavenPublication) {
-                from components.r2_10_6Release
-                groupId = "com.mux.stats.sdk.muxstats"
-                artifactId = "MuxExoPlayer_r2_10_6"
-                version = project.ext.versionName
-            }
-
-            r2_11_1Release(MavenPublication) {
-                from components.r2_11_1Release
-                groupId = "com.mux.stats.sdk.muxstats"
-                artifactId = "MuxExoPlayer_r2_11_1"
-                version = project.ext.versionName
-            }
-
-            r2_12_1Release(MavenPublication) {
-                from components.r2_12_1Release
-                groupId = "com.mux.stats.sdk.muxstats"
-                artifactId = "MuxExoPlayer_r2_12_1"
-                version = project.ext.versionName
-            }
-
-            r2_13_1Release(MavenPublication) {
-                from components.r2_13_1Release
-                groupId = "com.mux.stats.sdk.muxstats"
-                artifactId = "MuxExoPlayer_r2_13_1"
-                version = project.ext.versionName
-            }
-
-            r2_14_1Release(MavenPublication) {
-                from components.r2_14_1Release
-                groupId = "com.mux.stats.sdk.muxstats"
-                artifactId = "MuxExoPlayer_r2_14_1"
-                version = project.ext.versionName
-            }
-
-            r2_15_1Release(MavenPublication) {
-                from components.r2_15_1Release
-                groupId = "com.mux.stats.sdk.muxstats"
-                artifactId = "MuxExoPlayer_r2_15_1"
-                version = project.ext.versionName
+            publishing.publications.create(variant.name, MavenPublication) {
+                from components.findByName(variant.name)
+                groupId "com.mux.stats.sdk.muxstats"
+                artifactId "MuxExoPlayer_" + strippedExoPlayerVersion
+                version project.ext.versionName
             }
         }
     }


### PR DESCRIPTION
This is part of an effort to reduce the copy/paste that is occurring both between projects and within them. The follow up for this is to remove the "localDevFlag" and this PR helps move in that direction.

The changes are:
1. Update saucelabs runner image to hopefully improve stability there (There were suspicious connection failures occurring leading to the need to manually trigger retries - this appears to work)
2. Reorder the tests newest to oldest (as suggested by daytime-em)
3. Only perform saucelabs tests on oldest ExoPlayer versions when merging to master
4. Generate the sourceSets inclusion of Java directories for each flavour programatically
5. Generate the publishing declaration for each flavour programatically (this one was directly related to the localDevFlag work)