### PR TITLE
Fix for usage of legacy support libraries

### DIFF
--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -48,7 +48,7 @@ android {
 
         debug {
             // Note this is NOT a fat aar
-            minifyEnabled false
+            minifyEnabled true
         }
 
         release {

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -48,7 +48,7 @@ android {
 
         debug {
             // Note this is NOT a fat aar
-            minifyEnabled true
+            minifyEnabled false
         }
 
         release {

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -157,7 +157,6 @@ android {
 apply from: '../MuxAndroidSDKPublishing/declare_publication.gradle'
 
 dependencies {
-    implementation 'com.android.support:multidex:1.0.3'
     r2_9_6Api 'com.google.android.exoplayer:exoplayer:2.9.6'
     r2_9_6Api 'org.checkerframework:checker-qual:2.5.0'
     r2_9_6_adsApi 'com.google.android.exoplayer:exoplayer:2.9.6'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 ## Project-wide Gradle settings.
 buildDir=buildout
-android.enableR8=false
+android.enableR8=true
 android.enableDexingArtifactTransform.desugaring=false
 android.enableDexingArtifactTransform=false
 android.enableJetifier=true


### PR DESCRIPTION
As reported: https://github.com/muxinc/mux-stats-sdk-exoplayer/issues/174

This problem looks like something that was caused with the proguard integration at one time. Consequently the change appears here to be fairly simple since the other pieces are fixed.

- Removing multidex appeared to have no negative impact whatsoever
- Moved to enableR8 - R8 is the "new" obfuscator we should have been using anyway, but weren't because of those previous proguard problems