### PR TITLE
Fast escape on build error

### DIFF
--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -2,6 +2,8 @@
 #
 # Accessing the secret containing env vars in here prevents buildkite from capturing them
 
+set -e
+
 docker run -it -v --rm  \
     -v $(pwd):/data \
     -e BUILDKITE_BRANCH="$BUILDKITE_BRANCH" \

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -2,6 +2,8 @@
 #
 # Accessing the secret containing env vars in here prevents buildkite from capturing them
 
+set -e
+
 docker run -it -v --rm  \
     -v $(pwd):/data \
     -e BUILDKITE_BRANCH="$BUILDKITE_BRANCH" \

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -2,7 +2,7 @@ package com.mux.stats.sdk.muxstats;
 
 import static android.os.SystemClock.elapsedRealtime;
 
-import android.content.Context;
+//import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -2,7 +2,7 @@ package com.mux.stats.sdk.muxstats;
 
 import static android.os.SystemClock.elapsedRealtime;
 
-//import android.content.Context;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;


### PR DESCRIPTION
There have been a few too many occasions when we've been confused by build failures which actually occur in the first part of the build shell script while buildkite would make the failure of the second step far more visible even though it's not the root cause.

This change means if the first stage fails we fail immediately, and the logs end with the actual failure. There was a deliberate compilation error introduced to verify that this worked, then that was removed.