### PR TITLE
Update Dockerfile to be based on Java 11

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -11,7 +11,7 @@ docker run -it -v --rm  \
     -e ORG_GRADLE_PROJECT_artifactory_user=$ORG_GRADLE_PROJECT_artifactory_user \
     -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
     -w /data \
-    muxinc/mux-exoplayer:20210915 \
+    muxinc/mux-exoplayer:20220107 \
     bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:assemble MuxExoPlayer:artifactoryPublish"
 
 docker run -it -v --rm  \
@@ -23,5 +23,5 @@ docker run -it -v --rm  \
     -e ORG_GRADLE_PROJECT_artifactory_user=$ORG_GRADLE_PROJECT_artifactory_user \
     -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
     -w /data \
-    muxinc/mux-exoplayer:20210915 \
+    muxinc/mux-exoplayer:20220107 \
     bash -c "./gradlew --info automatedtests:assemble automatedtests:assembleAndroidTest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Based on https://github.com/ainoya/docker-android-project
 # then also from https://github.com/bitrise-io/android/blob/master/Dockerfile
-FROM openjdk:8u302
+FROM openjdk:11
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -11,7 +11,7 @@ ENV ANDROID_HOME /usr/local/android-sdk-linux
 # Install dependencies
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -yq libstdc++6:i386 zlib1g:i386 libncurses5:i386 --no-install-recommends
+    apt-get install -yq libstdc++6:i386 zlib1g:i386 libncurses5:i386 wget:i386 unzip:i386 git --no-install-recommends
 
 # Download and untar SDK
 RUN cd /usr/local && \
@@ -31,16 +31,8 @@ RUN sdkmanager "build-tools;29.0.3" "platform-tools" "extras;android;m2repositor
 ENV TERM dumb
 ENV JAVA_OPTS -Xms256m -Xmx512m
 
-# Add data into image so we can later pull an initial set of dependencies
-RUN mkdir /data
-COPY . /data
-WORKDIR /data
-
 # Configure the Android SDK and ack the license agreement
 RUN echo "sdk.dir=$ANDROID_HOME" > local.properties
-
-# Pull all our dependencies into the image
-RUN ./gradlew --info androidDependencies
 
 # Run build task by default
 CMD ./gradlew --info clean build


### PR DESCRIPTION
Update Docker build image to use Java 11. No longer bakes the entire repo into the image. Note that this doesn't change the Java compatibility for the SDK itself, which is set to Java 1.8 (8) in the Gradle config. We should, however, steer customers to use Java 11 in their build toolchain.

Image was built using the following steps:
 1. Building image without deps: `docker build . -t muxinc/mux-exoplayer:20220107`
 2. Starting a container with the image, mounting the repo into the container: `docker run --rm -ti   --mount type=bind,source="$(pwd)",target=/data  muxinc/mux-exoplayer:20220107 bash`
 3. Downloading and installing deps: `cd /data && ./gradlew --info androidDependencies`
 4. Committing the running container from a separate terminal: 
```
→ docker ps
CONTAINER ID   IMAGE                           COMMAND   CREATED         STATUS         PORTS     NAMES
727c1e805e1b   muxinc/mux-exoplayer:20220107   "bash"    4 minutes ago   Up 4 minutes             serene_nash

→ docker commit 727c1e805e1b muxinc/mux-exoplayer:20220107
sha256:d06a148639fa1162e9ba995c05b9fd5538589f0a637dba68b8932ef6a48be0b0
```
 5. Stopping the running container
 6. Pushing the committed image tag to Dockerhub: `docker push muxinc/mux-exoplayer:20220107`