### PR TITLE
Use Local Maven Repo for Gradle Deps still on Bintray

### DIFF
--- a/.buildkite/deploy.sh
+++ b/.buildkite/deploy.sh
@@ -13,5 +13,5 @@ docker run -it -v --rm  \
     -e ORG_GRADLE_PROJECT_artifactory_user=$ORG_GRADLE_PROJECT_artifactory_user \
     -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
     -w /data \
-    muxinc/mux-exoplayer:20220107 \
+    muxinc/mux-exoplayer:20220112 \
     bash -c "./gradlew --info muxReleaseDeploy"

--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -13,7 +13,7 @@ docker run -it -v --rm  \
     -e ORG_GRADLE_PROJECT_artifactory_user=$ORG_GRADLE_PROJECT_artifactory_user \
     -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
     -w /data \
-    muxinc/mux-exoplayer:20220107 \
+    muxinc/mux-exoplayer:20220112 \
     bash -c "./gradlew --info MuxExoPlayer:clean MuxExoPlayer:assemble MuxExoPlayer:artifactoryPublish"
 
 docker run -it -v --rm  \
@@ -25,5 +25,5 @@ docker run -it -v --rm  \
     -e ORG_GRADLE_PROJECT_artifactory_user=$ORG_GRADLE_PROJECT_artifactory_user \
     -e ORG_GRADLE_PROJECT_artifactory_password=$ORG_GRADLE_PROJECT_artifactory_password \
     -w /data \
-    muxinc/mux-exoplayer:20220107 \
+    muxinc/mux-exoplayer:20220112 \
     bash -c "./gradlew --info automatedtests:assemble automatedtests:assembleAndroidTest"

--- a/MuxAndroidSDKPublishing/publishing.gradle
+++ b/MuxAndroidSDKPublishing/publishing.gradle
@@ -40,6 +40,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
 
         repositories {
             maven {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
+        mavenLocal()
     }
 
     dependencies {
@@ -36,7 +36,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
+        mavenLocal()
 
         maven {
             url 'https://muxinc.jfrog.io/artifactory/default-maven-virtual'


### PR DESCRIPTION
Baked the Gradle publishing deps into the build image by installing in the local Maven repository:
```
mvn install:install-file -Dfile=build-info-extractor-gradle-4.23.4.jar -DpomFile=build-info-extractor-gradle.pom
```

Also, removed the JCenter repository since JCenter and Bintray have been [end-of-life'd](https://blog.gradle.org/jcenter-shutdown).