### PR TITLE
Request complete beacon limit

### DIFF
--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -1503,6 +1503,7 @@ public abstract class MuxBaseExoPlayer extends EventBus implements IPlayerListen
 
     private final BandwidthMetric bandwidthMetricHls = new BandwidthMetricHls();
     ArrayList<String> allowedHeaders = new ArrayList<>();
+    protected boolean debugModeOn = false;
     protected long requestSegmentDuration = 1000;
     protected long lastRequestSentAt = -1;
     protected int maxNumberOfEventsPerSegmentDuration = 3;
@@ -1604,7 +1605,7 @@ public abstract class MuxBaseExoPlayer extends EventBus implements IPlayerListen
     }
 
     private void dispatch(BandwidthMetricData data, PlaybackEvent event) {
-      if (data != null || shouldDispatchEvent(data, event)) {
+      if (data != null && shouldDispatchEvent(data, event)) {
         event.setBandwidthMetricData(data);
         MuxBaseExoPlayer.this.dispatch(event);
       }
@@ -1688,7 +1689,29 @@ public abstract class MuxBaseExoPlayer extends EventBus implements IPlayerListen
       if (numberOfRequestCompletedBeaconsSentPerSegment > maxNumberOfEventsPerSegmentDuration
         || numberOfRequestCancelBeaconsSentPerSegment > maxNumberOfEventsPerSegmentDuration
         || numberOfRequestFailedBeaconsSentPerSegment > maxNumberOfEventsPerSegmentDuration) {
+        if (debugModeOn) {
+          MuxLogger.d(TAG, "Dropping event: " + event.getType()
+              + "\nnumberOfRequestCompletedBeaconsSentPerSegment: "
+              + numberOfRequestCompletedBeaconsSentPerSegment
+              + "\nnumberOfRequestCancelBeaconsSentPerSegment: "
+              + numberOfRequestCancelBeaconsSentPerSegment
+              + "\nnumberOfRequestFailedBeaconsSentPerSegment: "
+              + numberOfRequestFailedBeaconsSentPerSegment
+              + "\ntimeDiff: " + timeDiff
+          );
+        }
         return false;
+      }
+      if (debugModeOn) {
+        MuxLogger.d(TAG, "All good: " + event.getType()
+            + "\nnumberOfRequestCompletedBeaconsSentPerSegment: "
+            + numberOfRequestCompletedBeaconsSentPerSegment
+            + "\nnumberOfRequestCancelBeaconsSentPerSegment: "
+            + numberOfRequestCancelBeaconsSentPerSegment
+            + "\nnumberOfRequestFailedBeaconsSentPerSegment: "
+            + numberOfRequestFailedBeaconsSentPerSegment
+            + "\ntimeDiff: " + timeDiff
+        );
       }
       return true;
     }

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -1567,7 +1567,7 @@ public abstract class MuxBaseExoPlayer extends EventBus implements IPlayerListen
     protected boolean debugModeOn = false;
     protected long requestSegmentDuration = 1000;
     protected long lastRequestSentAt = -1;
-    protected int maxNumberOfEventsPerSegmentDuration = 3;
+    protected int maxNumberOfEventsPerSegmentDuration = 10;
     protected int numberOfRequestCompletedBeaconsSentPerSegment = 0;
     protected int numberOfRequestCancelBeaconsSentPerSegment = 0;
     protected int numberOfRequestFailedBeaconsSentPerSegment = 0;


### PR DESCRIPTION
All bandwith metrics beacons limitted to maximum 3 events per segment duration, in case of the manifest file segment duration is 1 second.