### PR TITLE
Fix Build/Crash Issues When Used With Minimal/Custom ExoPlayers

### DIFF
--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -176,54 +176,54 @@ apply from: '../MuxAndroidSDKPublishing/declare_publication.gradle'
 dependencies {
     api 'org.checkerframework:checker-qual:2.5.0'
 
-  r2_9_6Api 'com.google.android.exoplayer:exoplayer-hls:2.9.6'
-  r2_9_6Api 'com.google.android.exoplayer:exoplayer-core:2.9.6'
-  r2_9_6_adsApi 'com.google.android.exoplayer:exoplayer-core:2.9.6'
-  r2_9_6_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.9.6'
+    r2_9_6Api 'com.google.android.exoplayer:exoplayer-core:2.9.6'
+    r2_9_6Api 'com.google.android.exoplayer:exoplayer-hls:2.9.6'
+    r2_9_6_adsApi 'com.google.android.exoplayer:exoplayer-core:2.9.6'
+    r2_9_6_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.9.6'
 
     r2_10_6Api 'com.google.android.exoplayer:exoplayer-core:2.10.6'
-  r2_10_6Api 'com.google.android.exoplayer:exoplayer-hls:2.10.6'
-  r2_10_6_adsApi 'com.google.android.exoplayer:exoplayer-core:2.10.6'
-  r2_10_6_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.10.6'
+    r2_10_6Api 'com.google.android.exoplayer:exoplayer-hls:2.10.6'
+    r2_10_6_adsApi 'com.google.android.exoplayer:exoplayer-core:2.10.6'
+    r2_10_6_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.10.6'
 
     r2_11_1Api 'com.google.android.exoplayer:exoplayer-core:2.11.1'
-  r2_11_1Api 'com.google.android.exoplayer:exoplayer-hls:2.11.1'
-  r2_11_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.11.1'
-  r2_11_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.11.1'
+    r2_11_1Api 'com.google.android.exoplayer:exoplayer-hls:2.11.1'
+    r2_11_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.11.1'
+    r2_11_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.11.1'
 
     r2_12_1Api 'com.google.android.exoplayer:exoplayer-core:2.12.1'
-  r2_12_1Api 'com.google.android.exoplayer:exoplayer-hls:2.12.1'
-  r2_12_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.12.1'
-  r2_12_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.12.1'
+    r2_12_1Api 'com.google.android.exoplayer:exoplayer-hls:2.12.1'
+    r2_12_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.12.1'
+    r2_12_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.12.1'
 
     r2_13_1Api 'com.google.android.exoplayer:exoplayer-core:2.13.1'
-  r2_13_1Api 'com.google.android.exoplayer:exoplayer-hls:2.13.1'
-  r2_13_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.13.1'
-  r2_13_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.13.1'
+    r2_13_1Api 'com.google.android.exoplayer:exoplayer-hls:2.13.1'
+    r2_13_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.13.1'
+    r2_13_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.13.1'
 
     r2_14_1Api 'com.google.android.exoplayer:exoplayer-core:2.14.1'
-  r2_14_1Api 'com.google.android.exoplayer:exoplayer-hls:2.14.1'
-  r2_14_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.14.1'
-  r2_14_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.14.1'
+    r2_14_1Api 'com.google.android.exoplayer:exoplayer-hls:2.14.1'
+    r2_14_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.14.1'
+    r2_14_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.14.1'
 
     r2_15_1Api 'com.google.android.exoplayer:exoplayer-core:2.15.1'
-  r2_15_1Api 'com.google.android.exoplayer:exoplayer-hls:2.15.1'
-  r2_15_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.15.1'
-  r2_15_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.15.1'
+    r2_15_1Api 'com.google.android.exoplayer:exoplayer-hls:2.15.1'
+    r2_15_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.15.1'
+    r2_15_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.15.1'
 
-  r2_16_1Api 'com.google.android.exoplayer:exoplayer-core:2.16.1'
-  r2_16_1Api 'com.google.android.exoplayer:exoplayer-hls:2.16.1'
+    r2_16_1Api 'com.google.android.exoplayer:exoplayer-core:2.16.1'
+    r2_16_1Api 'com.google.android.exoplayer:exoplayer-hls:2.16.1'
     r2_16_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.16.1'
-  r2_16_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.16.1'
+    r2_16_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.16.1'
 
-  // Amazon port doesn't delete any symbols (ever) & has no extensions, so we only need one version
+    // Amazon port doesn't delete any symbols (ever) & has no extensions, so we only need one version
     amznPortApi "com.amazon.android:exoplayer:2.16.1"
     amznPort_adsApi "com.amazon.android:exoplayer:2.16.1"
 
     r2_17_1Api 'com.google.android.exoplayer:exoplayer-core:2.17.1'
-  r2_17_1Api 'com.google.android.exoplayer:exoplayer-hls:2.17.1'
-  r2_17_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.17.1'
-  r2_17_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.17.1'
+    r2_17_1Api 'com.google.android.exoplayer:exoplayer-hls:2.17.1'
+    r2_17_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.17.1'
+    r2_17_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.17.1'
 
     compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.9.0'
     compileOnly 'com.google.android.gms:play-services-ads:15.0.1'

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -176,36 +176,54 @@ apply from: '../MuxAndroidSDKPublishing/declare_publication.gradle'
 dependencies {
     api 'org.checkerframework:checker-qual:2.5.0'
 
-    r2_9_6Api 'com.google.android.exoplayer:exoplayer:2.9.6'
-    r2_9_6_adsApi 'com.google.android.exoplayer:exoplayer:2.9.6'
+  r2_9_6Api 'com.google.android.exoplayer:exoplayer-hls:2.9.6'
+  r2_9_6Api 'com.google.android.exoplayer:exoplayer-core:2.9.6'
+  r2_9_6_adsApi 'com.google.android.exoplayer:exoplayer-core:2.9.6'
+  r2_9_6_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.9.6'
 
-    r2_10_6Api 'com.google.android.exoplayer:exoplayer:2.10.6'
-    r2_10_6_adsApi 'com.google.android.exoplayer:exoplayer:2.10.6'
+    r2_10_6Api 'com.google.android.exoplayer:exoplayer-core:2.10.6'
+  r2_10_6Api 'com.google.android.exoplayer:exoplayer-hls:2.10.6'
+  r2_10_6_adsApi 'com.google.android.exoplayer:exoplayer-core:2.10.6'
+  r2_10_6_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.10.6'
 
-    r2_11_1Api 'com.google.android.exoplayer:exoplayer:2.11.1'
-    r2_11_1_adsApi 'com.google.android.exoplayer:exoplayer:2.11.1'
+    r2_11_1Api 'com.google.android.exoplayer:exoplayer-core:2.11.1'
+  r2_11_1Api 'com.google.android.exoplayer:exoplayer-hls:2.11.1'
+  r2_11_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.11.1'
+  r2_11_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.11.1'
 
-    r2_12_1Api 'com.google.android.exoplayer:exoplayer:2.12.1'
-    r2_12_1_adsApi 'com.google.android.exoplayer:exoplayer:2.12.1'
+    r2_12_1Api 'com.google.android.exoplayer:exoplayer-core:2.12.1'
+  r2_12_1Api 'com.google.android.exoplayer:exoplayer-hls:2.12.1'
+  r2_12_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.12.1'
+  r2_12_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.12.1'
 
-    r2_13_1Api 'com.google.android.exoplayer:exoplayer:2.13.1'
-    r2_13_1_adsApi 'com.google.android.exoplayer:exoplayer:2.13.1'
+    r2_13_1Api 'com.google.android.exoplayer:exoplayer-core:2.13.1'
+  r2_13_1Api 'com.google.android.exoplayer:exoplayer-hls:2.13.1'
+  r2_13_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.13.1'
+  r2_13_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.13.1'
 
-    r2_14_1Api 'com.google.android.exoplayer:exoplayer:2.14.1'
-    r2_14_1_adsApi 'com.google.android.exoplayer:exoplayer:2.14.1'
+    r2_14_1Api 'com.google.android.exoplayer:exoplayer-core:2.14.1'
+  r2_14_1Api 'com.google.android.exoplayer:exoplayer-hls:2.14.1'
+  r2_14_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.14.1'
+  r2_14_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.14.1'
 
-    r2_15_1Api 'com.google.android.exoplayer:exoplayer:2.15.1'
-    r2_15_1_adsApi 'com.google.android.exoplayer:exoplayer:2.15.1'
+    r2_15_1Api 'com.google.android.exoplayer:exoplayer-core:2.15.1'
+  r2_15_1Api 'com.google.android.exoplayer:exoplayer-hls:2.15.1'
+  r2_15_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.15.1'
+  r2_15_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.15.1'
 
-    r2_16_1Api 'com.google.android.exoplayer:exoplayer:2.16.1'
-    r2_16_1_adsApi 'com.google.android.exoplayer:exoplayer:2.16.1'
+  r2_16_1Api 'com.google.android.exoplayer:exoplayer-core:2.16.1'
+  r2_16_1Api 'com.google.android.exoplayer:exoplayer-hls:2.16.1'
+    r2_16_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.16.1'
+  r2_16_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.16.1'
 
-    // Amazon's port doesn't delete any symbols (ever), so we only need one version
+  // Amazon port doesn't delete any symbols (ever) & has no extensions, so we only need one version
     amznPortApi "com.amazon.android:exoplayer:2.16.1"
     amznPort_adsApi "com.amazon.android:exoplayer:2.16.1"
 
-    r2_17_1Api 'com.google.android.exoplayer:exoplayer:2.17.1'
-    r2_17_1_adsApi 'com.google.android.exoplayer:exoplayer:2.17.1'
+    r2_17_1Api 'com.google.android.exoplayer:exoplayer-core:2.17.1'
+  r2_17_1Api 'com.google.android.exoplayer:exoplayer-hls:2.17.1'
+  r2_17_1_adsApi 'com.google.android.exoplayer:exoplayer-core:2.17.1'
+  r2_17_1_adsApi 'com.google.android.exoplayer:exoplayer-hls:2.17.1'
 
     compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.9.0'
     compileOnly 'com.google.android.gms:play-services-ads:15.0.1'

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -176,38 +176,36 @@ apply from: '../MuxAndroidSDKPublishing/declare_publication.gradle'
 dependencies {
     api 'org.checkerframework:checker-qual:2.5.0'
 
-    r2_9_6Implementation 'com.google.android.exoplayer:exoplayer:2.9.6'
-    r2_9_6_adsImplementation 'com.google.android.exoplayer:exoplayer:2.9.6'
+    r2_9_6Api 'com.google.android.exoplayer:exoplayer:2.9.6'
+    r2_9_6_adsApi 'com.google.android.exoplayer:exoplayer:2.9.6'
 
-    r2_10_6Implementation 'com.google.android.exoplayer:exoplayer:2.10.6'
-    r2_10_6_adsImplementation 'com.google.android.exoplayer:exoplayer:2.10.6'
+    r2_10_6Api 'com.google.android.exoplayer:exoplayer:2.10.6'
+    r2_10_6_adsApi 'com.google.android.exoplayer:exoplayer:2.10.6'
 
-    r2_11_1Implementation 'com.google.android.exoplayer:exoplayer:2.11.1'
-    r2_11_1_adsImplementation 'com.google.android.exoplayer:exoplayer:2.11.1'
+    r2_11_1Api 'com.google.android.exoplayer:exoplayer:2.11.1'
+    r2_11_1_adsApi 'com.google.android.exoplayer:exoplayer:2.11.1'
 
-    r2_12_1Implementation 'com.google.android.exoplayer:exoplayer:2.12.1'
-    r2_12_1_adsImplementation 'com.google.android.exoplayer:exoplayer:2.12.1'
+    r2_12_1Api 'com.google.android.exoplayer:exoplayer:2.12.1'
+    r2_12_1_adsApi 'com.google.android.exoplayer:exoplayer:2.12.1'
 
-    r2_13_1Implementation 'com.google.android.exoplayer:exoplayer:2.13.1'
-    r2_13_1_adsImplementation 'com.google.android.exoplayer:exoplayer:2.13.1'
+    r2_13_1Api 'com.google.android.exoplayer:exoplayer:2.13.1'
+    r2_13_1_adsApi 'com.google.android.exoplayer:exoplayer:2.13.1'
 
-    r2_14_1Implementation 'com.google.android.exoplayer:exoplayer:2.14.1'
-    r2_14_1_adsImplementation 'com.google.android.exoplayer:exoplayer:2.14.1'
+    r2_14_1Api 'com.google.android.exoplayer:exoplayer:2.14.1'
+    r2_14_1_adsApi 'com.google.android.exoplayer:exoplayer:2.14.1'
 
-    r2_15_1Implementation 'com.google.android.exoplayer:exoplayer:2.15.1'
-    r2_15_1_adsImplementation 'com.google.android.exoplayer:exoplayer:2.15.1'
+    r2_15_1Api 'com.google.android.exoplayer:exoplayer:2.15.1'
+    r2_15_1_adsApi 'com.google.android.exoplayer:exoplayer:2.15.1'
 
-    r2_16_1Implementation 'com.google.android.exoplayer:exoplayer:2.16.1'
-    r2_16_1_adsImplementation 'com.google.android.exoplayer:exoplayer:2.16.1'
+    r2_16_1Api 'com.google.android.exoplayer:exoplayer:2.16.1'
+    r2_16_1_adsApi 'com.google.android.exoplayer:exoplayer:2.16.1'
 
     // Amazon's port doesn't delete any symbols (ever), so we only need one version
-    amznPortImplementation "com.amazon.android:exoplayer:2.16.1"
-    amznPort_adsImplementation "com.amazon.android:exoplayer:2.16.1"
+    amznPortApi "com.amazon.android:exoplayer:2.16.1"
+    amznPort_adsApi "com.amazon.android:exoplayer:2.16.1"
 
-    r2_17_1Implementation 'com.google.android.exoplayer:exoplayer:2.17.1'
-    r2_17_1Implementation 'org.checkerframework:checker-qual:2.5.2'
-    r2_17_1_adsImplementation 'com.google.android.exoplayer:exoplayer:2.17.1'
-    r2_17_1_adsImplementation 'org.checkerframework:checker-qual:2.5.2'
+    r2_17_1Api 'com.google.android.exoplayer:exoplayer:2.17.1'
+    r2_17_1_adsApi 'com.google.android.exoplayer:exoplayer:2.17.1'
 
     compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.9.0'
     compileOnly 'com.google.android.gms:play-services-ads:15.0.1'

--- a/MuxExoPlayer/src/amznPort/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/amznPort/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -532,6 +532,8 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTimelineChanged(Timeline timeline, int reason) {
+    handleHlsManifest(player.get());
+
     if (timeline != null && timeline.getWindowCount() > 0) {
       Timeline.Window window = new Timeline.Window();
       timeline.getWindow(0, window);

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -354,7 +354,7 @@ public abstract class MuxBaseExoPlayer extends EventBus implements IPlayerListen
     if (foundHlsExtension == null) {
       try {
         // This class is for sure in the hls extension
-        Class.forName("com.google.android.exoplayer2.source.hls.HlsManifest");
+        Class.forName(HlsManifest.class.getCanonicalName());
         foundHlsExtension = true;
       } catch (ClassNotFoundException e) {
         MuxLogger.w(TAG, "exoplayer library-hls not available. Some features may not work");

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxBaseExoPlayer.java
@@ -366,13 +366,9 @@ public abstract class MuxBaseExoPlayer extends EventBus implements IPlayerListen
   }
 
   protected final void handleHlsManifest(ExoPlayer exoPlayer) {
-    Log.d("myfix", "handleHlsManifest(): is HLS available? " + isHlsExtensionAvailable());
-    Log.d("myfix", "handleHlsManifest(): exoPlayer is " + exoPlayer + " btw");
     if (exoPlayer != null && isHlsExtensionAvailable()) {
       // Don't reference this symbol unless the HLS extension is really available to use
       HlsManifest manifest = Util.safeCast(exoPlayer.getCurrentManifest(), HlsManifest.class);
-      Log.i("myfix", "Got HlsManifest " + manifest);
-      Log.i("myfix" , "For the record the manifest right now is " + exoPlayer.getCurrentManifest());
       if (manifest != null) {
         onMainPlaylistTags(manifest.masterPlaylist.tags);
       }

--- a/MuxExoPlayer/src/r2_10_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_10_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -348,13 +348,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTimelineChanged(Timeline timeline, Object manifest, int reason) {
-    ExoPlayer exoPlayer = player.get();
-    if(exoPlayer != null) {
-      HlsManifest hlsManifest = Util.safeCast(manifest, HlsManifest.class);
-      if(manifest != null) {
-        onMainPlaylistTags(hlsManifest.masterPlaylist.tags);
-      }
-    }
+    handleHlsManifest(player.get());
 
     if (timeline != null && timeline.getWindowCount() > 0) {
       Timeline.Window window = new Timeline.Window();

--- a/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_11_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -370,13 +370,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTimelineChanged(Timeline timeline, Object manifest, int reason) {
-    ExoPlayer exoPlayer = player.get();
-    if(exoPlayer != null) {
-      HlsManifest hlsManifest = Util.safeCast(manifest, HlsManifest.class);
-      if(hlsManifest != null) {
-        onMainPlaylistTags(hlsManifest.masterPlaylist.tags);
-      }
-    }
+    handleHlsManifest(player.get());
 
     if (timeline != null && timeline.getWindowCount() > 0) {
       Timeline.Window window = new Timeline.Window();

--- a/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_12_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -489,13 +489,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTimelineChanged(Timeline timeline, int reason) {
-    ExoPlayer exoPlayer = player.get();
-    if(exoPlayer != null) {
-      HlsManifest manifest = Util.safeCast(exoPlayer.getCurrentManifest(), HlsManifest.class);
-      if(manifest != null) {
-        onMainPlaylistTags(manifest.masterPlaylist.tags);
-      }
-    }
+    handleHlsManifest(player.get());
 
     if (timeline != null && timeline.getWindowCount() > 0) {
       Timeline.Window window = new Timeline.Window();

--- a/MuxExoPlayer/src/r2_13_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_13_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -485,13 +485,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTimelineChanged(Timeline timeline, int reason) {
-    ExoPlayer exoPlayer = player.get();
-    if(exoPlayer != null) {
-      HlsManifest manifest = Util.safeCast(exoPlayer.getCurrentManifest(), HlsManifest.class);
-      if(manifest != null) {
-        onMainPlaylistTags(manifest.masterPlaylist.tags);
-      }
-    }
+    handleHlsManifest(player.get());
 
     if (timeline != null && timeline.getWindowCount() > 0) {
       Timeline.Window window = new Timeline.Window();

--- a/MuxExoPlayer/src/r2_14_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_14_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -483,13 +483,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTimelineChanged(Timeline timeline, int reason) {
-    ExoPlayer exoPlayer = player.get();
-    if(exoPlayer != null) {
-      HlsManifest manifest = Util.safeCast(exoPlayer.getCurrentManifest(), HlsManifest.class);
-      if(manifest != null) {
-        onMainPlaylistTags(manifest.masterPlaylist.tags);
-      }
-    }
+    handleHlsManifest(player.get());
 
     if (timeline != null && timeline.getWindowCount() > 0) {
       Timeline.Window window = new Timeline.Window();

--- a/MuxExoPlayer/src/r2_15_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_15_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -537,13 +537,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTimelineChanged(Timeline timeline, int reason) {
-    ExoPlayer exoPlayer = player.get();
-    if(exoPlayer != null) {
-      HlsManifest manifest = Util.safeCast(exoPlayer.getCurrentManifest(), HlsManifest.class);
-      if(manifest != null) {
-        onMainPlaylistTags(manifest.masterPlaylist.tags);
-      }
-    }
+    handleHlsManifest(player.get());
 
     if (timeline != null && timeline.getWindowCount() > 0) {
       Timeline.Window window = new Timeline.Window();

--- a/MuxExoPlayer/src/r2_16_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_16_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -22,13 +22,14 @@ import com.google.android.exoplayer2.source.MediaLoadData;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.source.hls.HlsManifest;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
-import com.mux.stats.sdk.core.CustomOptions;
 import com.google.android.exoplayer2.video.VideoSize;
+import com.mux.stats.sdk.core.CustomOptions;
 import com.mux.stats.sdk.core.model.CustomerData;
 import com.mux.stats.sdk.core.model.CustomerPlayerData;
 import com.mux.stats.sdk.core.model.CustomerVideoData;
 import com.mux.stats.sdk.core.model.CustomerViewData;
 import com.mux.stats.sdk.core.util.MuxLogger;
+
 import java.io.IOException;
 
 public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsListener,
@@ -38,66 +39,66 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Deprecated
   public MuxStatsExoPlayer(Context ctx, ExoPlayer player, String playerName,
-      CustomerPlayerData customerPlayerData,
-      CustomerVideoData customerVideoData) {
+                           CustomerPlayerData customerPlayerData,
+                           CustomerVideoData customerVideoData) {
     this(ctx, player, playerName, customerPlayerData,
         customerVideoData, null, true);
   }
 
   @Deprecated
   public MuxStatsExoPlayer(Context ctx, ExoPlayer player, String playerName,
-      CustomerPlayerData customerPlayerData,
-      CustomerVideoData customerVideoData,
-      CustomerViewData customerViewData) {
+                           CustomerPlayerData customerPlayerData,
+                           CustomerVideoData customerVideoData,
+                           CustomerViewData customerViewData) {
     this(ctx, player, playerName, customerPlayerData, customerVideoData,
         customerViewData, true);
   }
 
   @Deprecated
   public MuxStatsExoPlayer(Context ctx, ExoPlayer player, String playerName,
-      CustomerPlayerData customerPlayerData,
-      CustomerVideoData customerVideoData,
-      @Deprecated boolean unused) {
+                           CustomerPlayerData customerPlayerData,
+                           CustomerVideoData customerVideoData,
+                           @Deprecated boolean unused) {
     this(ctx, player, playerName, customerPlayerData, customerVideoData,
         null, unused);
   }
 
   @Deprecated
   public MuxStatsExoPlayer(Context ctx, ExoPlayer player, String playerName,
-      CustomerPlayerData customerPlayerData,
-      CustomerVideoData customerVideoData,
-      CustomerViewData customerViewData, @Deprecated boolean unused) {
+                           CustomerPlayerData customerPlayerData,
+                           CustomerVideoData customerVideoData,
+                           CustomerViewData customerViewData, @Deprecated boolean unused) {
     this(ctx, player, playerName, new CustomerData(customerPlayerData, customerVideoData,
         customerViewData), unused, new MuxNetworkRequests());
   }
 
   @Deprecated
   public MuxStatsExoPlayer(Context ctx, ExoPlayer player, String playerName,
-      CustomerPlayerData customerPlayerData,
-      CustomerVideoData customerVideoData,
-      CustomerViewData customerViewData, @Deprecated boolean unused, INetworkRequest networkRequests) {
+                           CustomerPlayerData customerPlayerData,
+                           CustomerVideoData customerVideoData,
+                           CustomerViewData customerViewData, @Deprecated boolean unused, INetworkRequest networkRequests) {
     this(ctx, player, playerName, new CustomerData(customerPlayerData, customerVideoData,
         customerViewData), unused, networkRequests);
   }
 
   @Deprecated
   public MuxStatsExoPlayer(Context ctx, ExoPlayer player, String playerName,
-      CustomerData data,
-      @Deprecated boolean unused,
-      INetworkRequest networkRequests) {
+                           CustomerData data,
+                           @Deprecated boolean unused,
+                           INetworkRequest networkRequests) {
     this(ctx, player, playerName, data, new CustomOptions()
         , networkRequests);
   }
 
   public MuxStatsExoPlayer(Context ctx, ExoPlayer player, String playerName,
-      CustomerData data) {
+                           CustomerData data) {
     this(ctx, player, playerName, data, new CustomOptions(), new MuxNetworkRequests());
   }
 
   public MuxStatsExoPlayer(Context ctx, ExoPlayer player, String playerName,
-      CustomerData data,
-      CustomOptions options,
-      INetworkRequest networkRequests) {
+                           CustomerData data,
+                           CustomOptions options,
+                           INetworkRequest networkRequests) {
     super(ctx, player, playerName, data, options, networkRequests);
 
     player.addAnalyticsListener(this);
@@ -172,12 +173,12 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
   // ------BEGIN AnalyticsListener callbacks------
   @Override
   public void onAudioAttributesChanged(AnalyticsListener.EventTime eventTime,
-      AudioAttributes audioAttributes) {
+                                       AudioAttributes audioAttributes) {
   }
 
   @Override
   public void onAudioUnderrun(AnalyticsListener.EventTime eventTime, int bufferSize,
-      long bufferSizeMs, long elapsedSinceLastFeedMs) {
+                              long bufferSizeMs, long elapsedSinceLastFeedMs) {
   }
 
   @Override
@@ -187,7 +188,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onDownstreamFormatChanged(AnalyticsListener.EventTime eventTime,
-      MediaLoadData mediaLoadData) {
+                                        MediaLoadData mediaLoadData) {
     if (mediaLoadData.trackFormat != null
         && mediaLoadData.trackFormat.containerMimeType != null
         && detectMimeType) {
@@ -223,8 +224,8 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onLoadCanceled(AnalyticsListener.EventTime eventTime,
-      LoadEventInfo loadEventInfo,
-      MediaLoadData mediaLoadData) {
+                             LoadEventInfo loadEventInfo,
+                             MediaLoadData mediaLoadData) {
     if (loadEventInfo.uri != null) {
       bandwidthDispatcher
           .onLoadCanceled(loadEventInfo.loadTaskId, loadEventInfo.uri.getPath(),
@@ -237,8 +238,8 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onLoadCompleted(AnalyticsListener.EventTime eventTime,
-      LoadEventInfo loadEventInfo,
-      MediaLoadData mediaLoadData) {
+                              LoadEventInfo loadEventInfo,
+                              MediaLoadData mediaLoadData) {
     if (loadEventInfo.uri != null) {
       bandwidthDispatcher.onLoadCompleted(loadEventInfo.loadTaskId, loadEventInfo.uri.getPath(),
           loadEventInfo.bytesLoaded, mediaLoadData.trackFormat, loadEventInfo.responseHeaders);
@@ -250,9 +251,9 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onLoadError(AnalyticsListener.EventTime eventTime,
-      LoadEventInfo loadEventInfo,
-      MediaLoadData mediaLoadData, IOException e,
-      boolean wasCanceled) {
+                          LoadEventInfo loadEventInfo,
+                          MediaLoadData mediaLoadData, IOException e,
+                          boolean wasCanceled) {
     if (loadEventInfo.uri != null) {
       bandwidthDispatcher.onLoadError(loadEventInfo.loadTaskId, loadEventInfo.uri.getPath(), e);
     } else {
@@ -263,8 +264,8 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onLoadStarted(AnalyticsListener.EventTime eventTime,
-      LoadEventInfo loadEventInfo,
-      MediaLoadData mediaLoadData) {
+                            LoadEventInfo loadEventInfo,
+                            MediaLoadData mediaLoadData) {
     if (loadEventInfo.uri != null) {
       String segmentMimeType = "unknown";
       if (mediaLoadData.trackFormat != null && mediaLoadData.trackFormat.sampleMimeType != null) {
@@ -286,7 +287,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onPlaybackParametersChanged(AnalyticsListener.EventTime eventTime,
-      PlaybackParameters playbackParameters) {
+                                          PlaybackParameters playbackParameters) {
     onPlaybackParametersChanged(playbackParameters);
   }
 
@@ -297,7 +298,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onPlaybackSuppressionReasonChanged(AnalyticsListener.EventTime eventTime,
-      int playbackSuppressionReason) {
+                                                 int playbackSuppressionReason) {
   }
 
   @Override
@@ -307,7 +308,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onPlayWhenReadyChanged(AnalyticsListener.EventTime eventTime, boolean playWhenReady,
-      int reason) {
+                                     int reason) {
     onPlayWhenReadyChanged(playWhenReady, reason);
     onPlaybackStateChanged(player.get().getPlaybackState());
   }
@@ -331,13 +332,13 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onShuffleModeChanged(AnalyticsListener.EventTime eventTime,
-      boolean shuffleModeEnabled) {
+                                   boolean shuffleModeEnabled) {
     onShuffleModeEnabledChanged(shuffleModeEnabled);
   }
 
   @Override
   public void onSurfaceSizeChanged(AnalyticsListener.EventTime eventTime, int width,
-      int height) {
+                                   int height) {
   }
 
   @Override
@@ -347,7 +348,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTracksChanged(AnalyticsListener.EventTime eventTime, TrackGroupArray trackGroups,
-      TrackSelectionArray trackSelections) {
+                              TrackSelectionArray trackSelections) {
     onTracksChanged(trackGroups, trackSelections);
   }
 
@@ -534,13 +535,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTimelineChanged(Timeline timeline, int reason) {
-    ExoPlayer exoPlayer = player.get();
-    if(exoPlayer != null) {
-      HlsManifest manifest = Util.safeCast(exoPlayer.getCurrentManifest(), HlsManifest.class);
-      if(manifest != null) {
-        onMainPlaylistTags(manifest.masterPlaylist.tags);
-      }
-    }
+    handleHlsManifest(player.get());
 
     if (timeline != null && timeline.getWindowCount() > 0) {
       Timeline.Window window = new Timeline.Window();

--- a/MuxExoPlayer/src/r2_17_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_17_1/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -532,6 +532,8 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTimelineChanged(Timeline timeline, int reason) {
+    handleHlsManifest(player.get());
+
     if (timeline != null && timeline.getWindowCount() > 0) {
       Timeline.Window window = new Timeline.Window();
       timeline.getWindow(0, window);

--- a/MuxExoPlayer/src/r2_9_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
+++ b/MuxExoPlayer/src/r2_9_6/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.java
@@ -347,13 +347,7 @@ public class MuxStatsExoPlayer extends MuxBaseExoPlayer implements AnalyticsList
 
   @Override
   public void onTimelineChanged(Timeline timeline, Object manifest, int reason) {
-    ExoPlayer exoPlayer = player.get();
-    if(exoPlayer != null) {
-      HlsManifest hlsManifest = Util.safeCast(manifest, HlsManifest.class);
-      if(manifest != null) {
-        onMainPlaylistTags(hlsManifest.masterPlaylist.tags);
-      }
-    }
+    handleHlsManifest(player.get());
 
     if (timeline != null && timeline.getWindowCount() > 0) {
       Timeline.Window window = new Timeline.Window();

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -127,31 +127,40 @@ dependencies {
     api 'org.checkerframework:checker-qual:2.5.2'
 
     r2_9_6Api 'com.google.android.exoplayer:exoplayer:2.9.6'
+    r2_9_6Api 'com.google.android.exoplayer:exoplayer-ui:2.9.6'
     r2_9_6Api 'com.google.android.exoplayer:extension-mediasession:2.9.6'
 
     r2_10_6Api 'com.google.android.exoplayer:exoplayer:2.10.6'
+    r2_10_6Api 'com.google.android.exoplayer:exoplayer-ui:2.10.6'
     r2_10_6Api 'com.google.android.exoplayer:extension-mediasession:2.10.6'
 
     r2_11_1Api 'com.google.android.exoplayer:exoplayer:2.11.1'
+    r2_11_1Api 'com.google.android.exoplayer:exoplayer-ui:2.11.1'
     r2_11_1Api 'com.google.android.exoplayer:extension-mediasession:2.11.1'
 
     r2_12_1Api 'com.google.android.exoplayer:exoplayer:2.12.1'
+    r2_12_1Api 'com.google.android.exoplayer:exoplayer-ui:2.12.1'
     r2_12_1Api 'com.google.android.exoplayer:extension-mediasession:2.12.1'
 
 
     r2_13_1Api 'com.google.android.exoplayer:exoplayer:2.13.1'
+    r2_13_1Api 'com.google.android.exoplayer:exoplayer-ui:2.13.1'
     r2_13_1Api 'com.google.android.exoplayer:extension-mediasession:2.13.1'
 
     r2_14_1Api 'com.google.android.exoplayer:exoplayer:2.14.1'
+    r2_14_1Api 'com.google.android.exoplayer:exoplayer-ui:2.14.1'
     r2_14_1Api 'com.google.android.exoplayer:extension-mediasession:2.14.1'
 
     r2_15_1Api 'com.google.android.exoplayer:exoplayer:2.15.1'
+    r2_15_1Api 'com.google.android.exoplayer:exoplayer-ui:2.15.1'
     r2_15_1Api 'com.google.android.exoplayer:extension-mediasession:2.15.1'
 
     r2_16_1Api 'com.google.android.exoplayer:exoplayer:2.16.1'
+    r2_16_1Api 'com.google.android.exoplayer:exoplayer-ui:2.16.1'
     r2_16_1Api 'com.google.android.exoplayer:extension-mediasession:2.16.1'
 
     r2_17_1Api 'com.google.android.exoplayer:exoplayer:2.17.1'
+    r2_17_1Api 'com.google.android.exoplayer:exoplayer-ui:2.17.1'
     r2_17_1Api 'com.google.android.exoplayer:extension-mediasession:2.17.1'
 
     // Automated tests should always test the local module and not the maven dependency.

--- a/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/PlaybackTests.java
+++ b/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/PlaybackTests.java
@@ -16,7 +16,6 @@ import com.mux.stats.sdk.core.events.playback.ViewStartEvent;
 import com.mux.stats.sdk.core.model.CustomerVideoData;
 import com.mux.stats.sdk.core.model.PlayerData;
 import com.mux.stats.sdk.muxstats.MuxStatsExoPlayer;
-import com.mux.stats.sdk.muxstats.R;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -289,12 +289,8 @@ dependencies {
     r2_16_1_adsApi "com.google.android.gms:play-services-cronet:18.0.1"
     r2_16_1Api 'com.google.android.exoplayer:extension-cronet:2.16.1'
     r2_16_1Api 'com.google.android.exoplayer:extension-ima:2.16.1'
-  r2_16_1Api 'com.google.android.exoplayer:exoplayer-core:2.16.1'
-  r2_16_1Api 'com.google.android.exoplayer:exoplayer-ui:2.16.1'
-  r2_16_1Api 'com.google.android.exoplayer:exoplayer-hls:2.16.1'
-    r2_16_1Api ('com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_16_1:' + project.ext.versionName)
-  { exclude group:"com.google.android.exoplayer" }
-    //r2_16_1Api 'com.google.android.exoplayer:exoplayer:2.16.1'
+    r2_16_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_16_1:' + project.ext.versionName
+    r2_16_1Api 'com.google.android.exoplayer:exoplayer:2.16.1'
     r2_16_1_adsApi 'com.google.android.exoplayer:extension-cronet:2.16.1'
     r2_16_1_adsApi 'com.google.android.exoplayer:extension-ima:2.16.1'
     r2_16_1_adsApi 'com.google.android.exoplayer:exoplayer-common:2.16.1'

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -289,8 +289,12 @@ dependencies {
     r2_16_1_adsApi "com.google.android.gms:play-services-cronet:18.0.1"
     r2_16_1Api 'com.google.android.exoplayer:extension-cronet:2.16.1'
     r2_16_1Api 'com.google.android.exoplayer:extension-ima:2.16.1'
-    r2_16_1Api 'com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_16_1:' + project.ext.versionName
-    r2_16_1Api 'com.google.android.exoplayer:exoplayer:2.16.1'
+  r2_16_1Api 'com.google.android.exoplayer:exoplayer-core:2.16.1'
+  r2_16_1Api 'com.google.android.exoplayer:exoplayer-ui:2.16.1'
+  r2_16_1Api 'com.google.android.exoplayer:exoplayer-hls:2.16.1'
+    r2_16_1Api ('com.mux.stats.sdk.muxstats:MuxExoPlayer_r2_16_1:' + project.ext.versionName)
+  { exclude group:"com.google.android.exoplayer" }
+    //r2_16_1Api 'com.google.android.exoplayer:exoplayer:2.16.1'
     r2_16_1_adsApi 'com.google.android.exoplayer:extension-cronet:2.16.1'
     r2_16_1_adsApi 'com.google.android.exoplayer:extension-ima:2.16.1'
     r2_16_1_adsApi 'com.google.android.exoplayer:exoplayer-common:2.16.1'


### PR DESCRIPTION
This PR has three fixes related to issue #206:

* Use `api` instead of `implementation` for our `exoplayer` dependencies. Customers can include any source-compatible build of ExoPlayer without causing conflicts
* Fix a crash by checking for ExoPlayer's HLS module at runtime. Customers who aren't using HLS may prefer not to build the HLS module in at all.
* Depend on ExoPlayer in pieces. Customers who aren't using certain ExoPlayer modules (today, that's specifically `library-hls`) can remove the modules we use by doing: 
```groovy
implementation ("com.mux....:MuxExoPlayer_r2...:2.7.2")
  { exclude module: 'exoplayer-hls', module: 'exoplayer-somethingElse' /* etc */} 
```