### PR TITLE
Collect Request IDs for HLS segments for Error Tracking 

### DIFF
--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollectorBase.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/MuxStateCollectorBase.kt
@@ -114,7 +114,7 @@ abstract class MuxStateCollectorBase(
    * access play time info
    */
   var positionWatcher: PositionWatcher?
-          by Delegates.observable(null) @Synchronized { _, old, new ->
+          by Delegates.observable(null) @Synchronized { _, old, _ ->
             old?.apply { stop("watcher replaced") }
           }
 

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/BandwidthMetric.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/BandwidthMetric.kt
@@ -331,12 +331,7 @@ internal class BandwidthMetricDispatcher(player: ExoPlayer,
     fun dispatch(data: BandwidthMetricData, event: PlaybackEvent) {
         if (shouldDispatchEvent(data, event)) {
             event.bandwidthMetricData = data
-
-            data.requestResponseHeaders?.let { headers ->
-                headers["x-request-id"]?.let {
-                  // TODO: Add to BandwidthMetricData
-                }
-            }
+            data.requestId = data.requestResponseHeaders?.get("x-request-id")
 
             collector?.dispatch(event)
         }

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/BandwidthMetric.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/BandwidthMetric.kt
@@ -1,6 +1,5 @@
 package com.mux.stats.sdk.muxstats.internal
 
-import android.util.Log
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.Format
@@ -150,11 +149,9 @@ internal open class BandwidthMetric(val player: ExoPlayer, val collector: MuxSta
                            segmentUrl:String?, dataType:Int, host:String?, segmentMimeType:String?,
                            segmentWidth:Int, segmentHeight:Int)
             : BandwidthMetricData {
-        val loadData:BandwidthMetricData = onLoad(loadTaskId, mediaStartTimeMs, mediaEndTimeMs
+        val loadData = onLoad(loadTaskId, mediaStartTimeMs, mediaEndTimeMs
             , segmentUrl, dataType, host, segmentMimeType, segmentWidth, segmentHeight)
-        if (loadData != null) {
-            loadData.setRequestResponseStart(System.currentTimeMillis())
-        }
+        loadData.requestResponseStart = System.currentTimeMillis()
         return loadData
     }
 

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/BandwidthMetric.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/BandwidthMetric.kt
@@ -294,7 +294,8 @@ internal class BandwidthMetricDispatcher(player: ExoPlayer,
     fun parseHeaders(loadData:BandwidthMetricData, responseHeaders:Map<String, List<String>>) {
       val headers: Hashtable<String, String>? = parseHeaders(responseHeaders)
       if (headers != null) {
-          loadData.setRequestResponseHeaders(headers)
+        loadData.requestId = headers["x-request-id"]
+        loadData.requestResponseHeaders = headers
       }
     }
 
@@ -331,8 +332,6 @@ internal class BandwidthMetricDispatcher(player: ExoPlayer,
     fun dispatch(data: BandwidthMetricData, event: PlaybackEvent) {
         if (shouldDispatchEvent(data, event)) {
             event.bandwidthMetricData = data
-            data.requestId = data.requestResponseHeaders?.get("x-request-id")
-
             collector?.dispatch(event)
         }
     }
@@ -343,7 +342,7 @@ internal class BandwidthMetricDispatcher(player: ExoPlayer,
         }
 
         val headers:Hashtable<String, String> = Hashtable<String, String>()
-        for (headerName in responseHeaders.keys ) {
+        for (headerName in responseHeaders.keys) {
             var headerAllowed = false
             synchronized (this) {
                 for (allowedHeader in collector!!.allowedHeaders) {
@@ -365,8 +364,8 @@ internal class BandwidthMetricDispatcher(player: ExoPlayer,
                 // it down to a single comma-separated value per RFC 2616
                 // https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
                 var headerValue:String = headerValues[0]
-                for (i in 1 until  headerValues.size) {
-                    headerValue = headerValue + ", " + headerValues.get(i);
+                for (i in 1 until headerValues.size) {
+                    headerValue = headerValue + ", " + headerValues[i];
                 }
                 headers[headerName] = headerValue;
             }

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/BandwidthMetric.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/BandwidthMetric.kt
@@ -285,8 +285,6 @@ internal class BandwidthMetricDispatcher(player: ExoPlayer,
             loadTaskId, segmentUrl, bytesLoaded, trackFormat)
         if (loadData != null) {
             parseHeaders(loadData, responseHeaders)
-            // TODO: Some response headers go on the Event. Will this happen enough to warrant some higher-level config?
-            //  No! it will not. Just put it on BandwidthMetricData
             dispatch(loadData, RequestCompleted(null))
         }
     }

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
@@ -249,15 +249,16 @@ class MuxStatsExoPlayer @JvmOverloads constructor(
     }
     try {
       // TODO: these may not be necessary, but doing it for the sake of it
-      adsLoader.addAdsLoadedListener(AdsLoader.AdsLoadedListener { adsManagerLoadedEvent -> // TODO: Add in the adresponse stuff when we can
+      adsLoader.addAdsLoadedListener(AdsLoader.AdsLoadedListener { adsManagerLoadedEvent ->
         // Set up the ad events that we want to use
         val adsManager = adsManagerLoadedEvent.adsManager
         // Attach mux event and error event listeners.
         adsManager.addAdErrorListener(imaSdkListener)
         adsManager.addAdEventListener(imaSdkListener)
-      } // TODO: probably need to handle some cleanup and things, like removing listeners on destroy
+      }
       )
-    } catch (cnfe: ClassNotFoundException) {
+    } catch (imaNotInClasspath: ClassNotFoundException) {
+      // If no IMA classes at runtime just return harmlessly
       return
     }
   }
@@ -491,6 +492,7 @@ class MuxStatsExoPlayer @JvmOverloads constructor(
  * Basic device details such as OS version, vendor name and etc. Instances of this class
  * are used by [MuxStats] to interface with the device.
  */
+@Suppress("DEPRECATION") // Don't worry, this will be removed soon
 private class MuxDevice(ctx: Context) : IDevice {
 
   private var contextRef: WeakReference<Context>
@@ -569,41 +571,37 @@ private class MuxDevice(ctx: Context) : IDevice {
     val context = contextRef.get() ?: return null
     val connectivityMgr = context
       .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-    var activeNetwork: NetworkInfo? = null
-    if (connectivityMgr != null) {
-      activeNetwork = connectivityMgr.activeNetworkInfo
-      return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        val nc = connectivityMgr
-          .getNetworkCapabilities(connectivityMgr.activeNetwork)
-        if (nc == null) {
-          MuxLogger.d(
-            TAG,
-            "ERROR: Failed to obtain NetworkCapabilities manager !!!"
-          )
-          return null
-        }
-        if (nc.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
-          CONNECTION_TYPE_WIRED
-        } else if (nc.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
-          CONNECTION_TYPE_WIFI
-        } else if (nc.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-          CONNECTION_TYPE_CELLULAR
-        } else {
-          CONNECTION_TYPE_OTHER
-        }
+    val activeNetwork: NetworkInfo? = connectivityMgr.activeNetworkInfo
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      val nc = connectivityMgr
+        .getNetworkCapabilities(connectivityMgr.activeNetwork)
+      if (nc == null) {
+        MuxLogger.d(
+          TAG,
+          "ERROR: Failed to obtain NetworkCapabilities manager !!!"
+        )
+        return null
+      }
+      if (nc.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+        CONNECTION_TYPE_WIRED
+      } else if (nc.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+        CONNECTION_TYPE_WIFI
+      } else if (nc.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+        CONNECTION_TYPE_CELLULAR
       } else {
-        if (activeNetwork!!.type == ConnectivityManager.TYPE_ETHERNET) {
-          CONNECTION_TYPE_WIRED
-        } else if (activeNetwork.type == ConnectivityManager.TYPE_WIFI) {
-          CONNECTION_TYPE_WIFI
-        } else if (activeNetwork.type == ConnectivityManager.TYPE_MOBILE) {
-          CONNECTION_TYPE_CELLULAR
-        } else {
-          CONNECTION_TYPE_OTHER
-        }
+        CONNECTION_TYPE_OTHER
+      }
+    } else {
+      if (activeNetwork!!.type == ConnectivityManager.TYPE_ETHERNET) {
+        CONNECTION_TYPE_WIRED
+      } else if (activeNetwork.type == ConnectivityManager.TYPE_WIFI) {
+        CONNECTION_TYPE_WIFI
+      } else if (activeNetwork.type == ConnectivityManager.TYPE_MOBILE) {
+        CONNECTION_TYPE_CELLULAR
+      } else {
+        CONNECTION_TYPE_OTHER
       }
     }
-    return null
   }
 
   override fun getElapsedRealtime(): Long {
@@ -644,12 +642,6 @@ private class MuxDevice(ctx: Context) : IDevice {
     val muxStatsInstance = MuxStats.getHostDevice() as? MuxDevice
   }
 
-  /**
-   * Basic constructor.
-   *
-   * @param ctx activity context, we use this to access different system services, like
-   * [ConnectivityManager], or [PackageInfo].
-   */
   init {
     val sharedPreferences = ctx
       .getSharedPreferences(MUX_DEVICE_ID, Context.MODE_PRIVATE)
@@ -658,7 +650,7 @@ private class MuxDevice(ctx: Context) : IDevice {
       deviceId = UUID.randomUUID().toString()
       val editor = sharedPreferences.edit()
       editor.putString(MUX_DEVICE_ID, deviceId)
-      editor.commit()
+      editor.apply()
     }
     contextRef = WeakReference(ctx)
     try {

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
@@ -209,6 +209,7 @@ class MuxStatsExoPlayer @JvmOverloads constructor(
     // We always need these two values.
     collector.allowHeaderToBeSentToBackend("x-cdn")
     collector.allowHeaderToBeSentToBackend("content-type")
+    collector.allowHeaderToBeSentToBackend("x-request-id")
   }
 
   /**

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ allprojects {
     compileSdkVersion = 31
     targetSdkVersion = 31
 
-    muxCoreVersion = "dev-ed/add-request-id-e946b03"
+    muxCoreVersion = "7.3.2"
     kotlinxCoroutinesVersion = "1.6.1"
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ allprojects {
     compileSdkVersion = 31
     targetSdkVersion = 31
 
-    muxCoreVersion = "7.3.1"
+    muxCoreVersion = "dev-ed/add-request-id-e946b03"
     kotlinxCoroutinesVersion = "1.6.1"
   }
 }


### PR DESCRIPTION
This PR collects the `x-request-id` header from HLS segment responses that come in. It collects the header in the normal way, but also adds it to the Event. This is so that Core can offer an alternative way of setting the request ID to our custom integrators

This PR also fixes a bunch of warnings. I fixed ones near what I was working on, but I got a little carried away

This PR should stay a draft until Core is officially released with the changes to `BandwidthMetricData`