### PR TITLE
Device category override issue

### DIFF
--- a/ExoPlayerAdapter/build.gradle
+++ b/ExoPlayerAdapter/build.gradle
@@ -155,7 +155,7 @@ muxDistribution {
 
 dependencies {
 //  api "com.mux:stats.muxcore:${project.ext.muxCoreVersion}"
-  api "com.mux:stats.muxcore:dev-device_category_override_issue-aaf96bd"
+  api "com.mux:stats.muxcore:dev-device_category_override_issue-f9ff7dc"
 
   //noinspection GradleDynamicVersion,GradleDependency
   r2_10_6Api 'com.google.android.exoplayer:exoplayer:2.10.6'

--- a/ExoPlayerAdapter/build.gradle
+++ b/ExoPlayerAdapter/build.gradle
@@ -154,7 +154,9 @@ muxDistribution {
 }
 
 dependencies {
-  api "com.mux:stats.muxcore:${project.ext.muxCoreVersion}"
+//  api "com.mux:stats.muxcore:${project.ext.muxCoreVersion}"
+  api "com.mux:stats.muxcore:dev-device_category_override_issue-aaf96bd"
+
   //noinspection GradleDynamicVersion,GradleDependency
   r2_10_6Api 'com.google.android.exoplayer:exoplayer:2.10.6'
   //noinspection GradleDynamicVersion,GradleDependency

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -156,7 +156,8 @@ dependencies {
   compileOnly 'com.google.android.gms:play-services-ads-identifier:15.0.1'
 
   debugImplementation project(':ExoPlayerAdapter')
-  api "com.mux:stats.muxcore:${project.ext.muxCoreVersion}"
+//  api "com.mux:stats.muxcore:${project.ext.muxCoreVersion}"
+  api "com.mux:stats.muxcore:dev-device_category_override_issue-aaf96bd"
 }
 
 afterEvaluate {

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -157,7 +157,7 @@ dependencies {
 
   debugImplementation project(':ExoPlayerAdapter')
 //  api "com.mux:stats.muxcore:${project.ext.muxCoreVersion}"
-  api "com.mux:stats.muxcore:dev-device_category_override_issue-aaf96bd"
+  api "com.mux:stats.muxcore:dev-device_category_override_issue-f9ff7dc"
 }
 
 afterEvaluate {

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
@@ -270,25 +270,11 @@ class MuxStatsExoPlayer @JvmOverloads constructor(
   inline fun <reified T : View> getExoPlayerView(): T? = playerView as? T
 
   /**
-   * Overwrite the OS version reported on the Mux Data dashboard for views recorded with this object
+   * Overwrite the device category
    */
-  fun overwriteOsVersion(osVersion: String) {
-    MuxDevice.muxStatsInstance?.overwrittenOsVersion = osVersion
-  }
-
-  /**
-   * Overwrite the device name reported on the Mux Data dashboard for views recorded with this object
-   */
-  fun overwriteDeviceName(deviceName: String) {
-    MuxDevice.muxStatsInstance?.overwrittenDeviceName = deviceName
-  }
-
-  /**
-   * Overwrite the OS Family name (Such as 'Android')  reported on the Mux Data dashboard for views
-   * recorded with this object
-   */
-  fun overwriteOsFamily(osFamily: String) {
-    MuxDevice.muxStatsInstance?.overwrittenOsFamilyName = osFamily
+  fun overwriteDeviceCategory(category: String) {
+    MuxDevice.muxStatsInstance?.overwrittenDeviceCategory = category
+    muxStats.updateHostDeviceData()
   }
 
   /**
@@ -297,6 +283,40 @@ class MuxStatsExoPlayer @JvmOverloads constructor(
    */
   fun overwriteManufacturer(manufacturer: String) {
     MuxDevice.muxStatsInstance?.overwrittenManufacturer = manufacturer
+    muxStats.updateHostDeviceData()
+  }
+
+  /**
+   * Overwrite the device name reported on the Mux Data dashboard for views recorded with this object
+   */
+  fun overwriteDeviceName(deviceName: String) {
+    MuxDevice.muxStatsInstance?.overwrittenDeviceName = deviceName
+    muxStats.updateHostDeviceData()
+  }
+
+  /**
+   * Overwrite the OS Family name (Such as 'Android')  reported on the Mux Data dashboard for views
+   * recorded with this object
+   */
+  fun overwriteOsFamily(osFamily: String) {
+    MuxDevice.muxStatsInstance?.overwrittenOsFamilyName = osFamily
+    muxStats.updateHostDeviceData()
+  }
+
+  /**
+   * Overwrite the OS version reported on the Mux Data dashboard for views recorded with this object
+   */
+  fun overwriteOsVersion(osVersion: String) {
+    MuxDevice.muxStatsInstance?.overwrittenOsVersion = osVersion
+    muxStats.updateHostDeviceData()
+  }
+
+  /**
+   * Overwrite the device model reported on the Mux Data dashboard for views recorded with this object
+   */
+  fun overwriteDeviceModel(deviceModel: String) {
+    MuxDevice.muxStatsInstance?.overwrittenDeviceModelName = deviceModel
+    muxStats.updateHostDeviceData()
   }
 
   /**
@@ -305,6 +325,7 @@ class MuxStatsExoPlayer @JvmOverloads constructor(
    */
   fun updateCustomerData(customerData: CustomerData) {
     muxStats.customerData = customerData
+    muxStats.updateHostDeviceData()
   }
 
   /**
@@ -498,7 +519,9 @@ private class MuxDevice(ctx: Context) : IDevice {
   private var appName = ""
   private var appVersion = ""
 
+  var overwrittenDeviceCategory: String? = null
   var overwrittenDeviceName: String? = null
+  var overwrittenDeviceModelName: String? = null
   var overwrittenOsFamilyName: String? = null
   var overwrittenOsVersion: String? = null
   var overwrittenManufacturer: String? = null
@@ -511,13 +534,23 @@ private class MuxDevice(ctx: Context) : IDevice {
     return "Android"
   }
 
-  override fun getMuxOSFamily(): String? = overwrittenOsFamilyName
+  override fun getMuxOSFamily(): String? {
+    return overwrittenOsFamilyName
+  }
 
   override fun getOSVersion(): String {
     return Build.VERSION.RELEASE + " (" + Build.VERSION.SDK_INT + ")"
   }
 
   override fun getMuxOSVersion(): String? = overwrittenOsVersion
+
+  override fun getDeviceName(): String = ""
+
+  override fun getMuxDeviceName(): String? = overwrittenDeviceName
+
+  override fun getDeviceCategory(): String = ""
+
+  override fun getMuxDeviceCategory(): String? = overwrittenDeviceCategory
 
   override fun getManufacturer(): String {
     return Build.MANUFACTURER
@@ -529,7 +562,7 @@ private class MuxDevice(ctx: Context) : IDevice {
     return Build.MODEL
   }
 
-  override fun getMuxModelName(): String? = overwrittenDeviceName
+  override fun getMuxModelName(): String? = overwrittenDeviceModelName
 
   override fun getPlayerVersion(): String {
     return ExoPlayerLibraryInfo.VERSION
@@ -641,7 +674,7 @@ private class MuxDevice(ctx: Context) : IDevice {
     const val CONNECTION_TYPE_OTHER = "other"
     const val MUX_DEVICE_ID = "MUX_DEVICE_ID"
 
-    val muxStatsInstance = MuxStats.getHostDevice() as? MuxDevice
+    val muxStatsInstance get() = MuxStats.getHostDevice() as? MuxDevice
   }
 
   /**

--- a/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/SimplePlayerBaseActivity.java
+++ b/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/SimplePlayerBaseActivity.java
@@ -32,6 +32,7 @@ import com.mux.stats.sdk.core.model.CustomerData;
 import com.mux.stats.sdk.core.model.CustomerPlayerData;
 import com.mux.stats.sdk.core.model.CustomerVideoData;
 import com.mux.stats.sdk.muxstats.automatedtests.BuildConfig;
+import com.mux.stats.sdk.muxstats.automatedtests.PlaybackTests;
 import com.mux.stats.sdk.muxstats.automatedtests.R;
 import com.mux.stats.sdk.muxstats.automatedtests.mockup.MockNetworkRequest;
 
@@ -213,6 +214,14 @@ public abstract class SimplePlayerBaseActivity extends AppCompatActivity {
     muxStats.setScreenSize(size.x, size.y);
     muxStats.setPlayerView(playerView);
     muxStats.enableMuxCoreDebug(true, false);
+    // set some dummy overwriotes
+    muxStats.overwriteDeviceCategory(PlaybackTests.DEVICE_CATEGORY_OVERRIDE);
+    muxStats.overwriteManufacturer(PlaybackTests.DEVICE_MANUFACTURER_OVERRIDE);
+    muxStats.overwriteDeviceName(PlaybackTests.DEVICE_NAME_OVERRIDE);
+    muxStats.overwriteOsFamily(PlaybackTests.DEVICE_OS_FAMILY_OVERRIDE);
+    muxStats.overwriteOsVersion(PlaybackTests.DEVICE_OS_VERSION_OVERRIDE);
+    muxStats.overwriteDeviceModel(PlaybackTests.DEVICE_MODEL_OVERRIDE);
+
     for (String headerName : addAllowedHeaders) {
       MuxStatsHelper.allowHeaderToBeSentToBackend(muxStats, headerName);
     }


### PR DESCRIPTION
API to overwrite Device stats such as OS family device category and name implemented, API tested in playback tests.