### PR TITLE
Stop generating javadoc until we are hosting it, it's too slow

### DIFF
--- a/ExoPlayerAdapter/build.gradle
+++ b/ExoPlayerAdapter/build.gradle
@@ -144,8 +144,8 @@ muxDistribution {
   groupIds just("com.mux.stats.sdk.muxstats")
   publicReleaseIf releaseOnTag()
 
-  // Sadly, it takes too long to build them for each variant until we actually host them somewhere
-  packageJavadocs = false
+  // TODO: This is kinda clumsy, packageJavadocs should be a function not a property probably
+  packageJavadocs = releaseOnTag().call()
   publishIf { it.containsIgnoreCase("release") }
   artifactoryConfig {
     contextUrl = "https://muxinc.jfrog.io/artifactory/"

--- a/ExoPlayerAdapter/build.gradle
+++ b/ExoPlayerAdapter/build.gradle
@@ -144,7 +144,8 @@ muxDistribution {
   groupIds just("com.mux.stats.sdk.muxstats")
   publicReleaseIf releaseOnTag()
 
-  packageJavadocs = System.getenv("GITHUB_ACTIONS") != null
+  // Sadly, it takes too long to build them for each variant until we actually host them somewhere
+  packageJavadocs = false
   publishIf { it.containsIgnoreCase("release") }
   artifactoryConfig {
     contextUrl = "https://muxinc.jfrog.io/artifactory/"

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -118,7 +118,8 @@ muxDistribution {
   publishIf { it.containsIgnoreCase("release") }
   publicReleaseIf releaseOnTag()
 
-  packageJavadocs = System.getenv("GITHUB_ACTIONS") != null
+  // Sadly, it takes too long to build them for each variant until we actually host them somewhere
+  packageJavadocs = false
   artifactoryConfig {
     contextUrl = "https://muxinc.jfrog.io/artifactory/"
     releaseRepoKey = 'default-maven-release-local'

--- a/MuxExoPlayer/build.gradle
+++ b/MuxExoPlayer/build.gradle
@@ -118,8 +118,8 @@ muxDistribution {
   publishIf { it.containsIgnoreCase("release") }
   publicReleaseIf releaseOnTag()
 
-  // Sadly, it takes too long to build them for each variant until we actually host them somewhere
-  packageJavadocs = false
+  // TODO: This is kinda clumsy, packageJavadocs should be a function not a property probably
+  packageJavadocs = releaseOnTag().call()
   artifactoryConfig {
     contextUrl = "https://muxinc.jfrog.io/artifactory/"
     releaseRepoKey = 'default-maven-release-local'


### PR DESCRIPTION
This saves about 9 minutes of ci time. It would be neat to build javadoc automatically and stitch it together with MuxCore's somehow, but we wouldn't need to do that except when releasing anyway, and might want to do it after deploying to prod or something for instance