### PR TITLE
Exo 2.11: Drop renditionchange events that don't have any data

### DIFF
--- a/ExoPlayerAdapter/src/exo-analytics-listener-upto-2_11/java/com/mux/stats/sdk/muxstats/internal/ExoAnalyticsListener.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-listener-upto-2_11/java/com/mux/stats/sdk/muxstats/internal/ExoAnalyticsListener.kt
@@ -8,6 +8,7 @@ import com.google.android.exoplayer2.source.MediaSourceEventListener.LoadEventIn
 import com.google.android.exoplayer2.source.MediaSourceEventListener.MediaLoadData
 import com.google.android.exoplayer2.source.TrackGroupArray
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray
+import com.mux.stats.sdk.core.util.MuxLogger
 import com.mux.stats.sdk.muxstats.MuxStateCollector
 import java.io.IOException
 
@@ -80,12 +81,20 @@ private class ExoAnalyticsListener(player: ExoPlayer, val collector: MuxStateCol
 
   override fun onDecoderInputFormatChanged(eventTime: EventTime, trackType: Int, format: Format) {
     if(trackType == C.TRACK_TYPE_VIDEO) {
-      collector.renditionChange(
-        advertisedBitrate = format.bitrate,
-        advertisedFrameRate = format.frameRate,
-        sourceHeight = format.height,
-        sourceWidth = format.width,
-      )
+      // Filter out empty rendition-change events
+      if(format.bitrate == Format.NO_VALUE
+        && format.frameRate == Format.NO_VALUE.toFloat()
+        && format.width == Format.NO_VALUE
+        && format.height == Format.NO_VALUE) {
+        MuxLogger.d("ExoAnalyticsListener", "Empty renditionchange event skipped");
+      } else {
+        collector.renditionChange(
+          advertisedBitrate = format.bitrate,
+          advertisedFrameRate = format.frameRate,
+          sourceHeight = format.height,
+          sourceWidth = format.width,
+        )
+      }
     }
   }
 


### PR DESCRIPTION
If the event is totally blank, this is assumed to be callback noise. In my testing (using the 'Track Selection' dialog in the sample app) I found that such events were always accompanied by ones that did have data.