### PR TITLE
Overriding device data new api

### DIFF
--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
@@ -274,32 +274,40 @@ class MuxStatsExoPlayer @JvmOverloads constructor(
   /**
    * Overwrite the OS version reported on the Mux Data dashboard for views recorded with this object
    */
-  fun overwriteOsVersion(osVersion: String) {
-    MuxDevice.muxStatsInstance?.overwrittenOsVersion = osVersion
-  }
+  @Deprecated(
+    message = "This method is not used by MuxCore any more",
+    replaceWith = ReplaceWith("CustomerViewerData")
+  )
+  fun overwriteOsVersion(osVersion: String) {}
 
   /**
    * Overwrite the device name reported on the Mux Data dashboard for views recorded with this object
    */
-  fun overwriteDeviceName(deviceName: String) {
-    MuxDevice.muxStatsInstance?.overwrittenDeviceName = deviceName
-  }
+  @Deprecated(
+    message = "This method is not used by MuxCore any more",
+    replaceWith = ReplaceWith("CustomerViewerData")
+  )
+  fun overwriteDeviceName(deviceName: String) {}
 
   /**
    * Overwrite the OS Family name (Such as 'Android')  reported on the Mux Data dashboard for views
    * recorded with this object
    */
-  fun overwriteOsFamily(osFamily: String) {
-    MuxDevice.muxStatsInstance?.overwrittenOsFamilyName = osFamily
-  }
+  @Deprecated(
+    message = "This method is not used by MuxCore any more",
+    replaceWith = ReplaceWith("CustomerViewerData")
+  )
+  fun overwriteOsFamily(osFamily: String) {}
 
   /**
    * Overwrite the OS Family name (Such as 'Android')  reported on the Mux Data dashboard for views
    * recorded with this object
    */
-  fun overwriteManufacturer(manufacturer: String) {
-    MuxDevice.muxStatsInstance?.overwrittenManufacturer = manufacturer
-  }
+  @Deprecated(
+    message = "This method is not used by MuxCore any more",
+    replaceWith = ReplaceWith("CustomerViewerData")
+  )
+  fun overwriteManufacturer(manufacturer: String) {}
 
   /**
    * Update all Customer Data (custom player, video, and view data) with the data found here
@@ -501,10 +509,6 @@ private class MuxDevice(ctx: Context) : IDevice {
   private var appName = ""
   private var appVersion = ""
 
-  var overwrittenDeviceName: String? = null
-  var overwrittenOsFamilyName: String? = null
-  var overwrittenOsVersion: String? = null
-  var overwrittenManufacturer: String? = null
 
   override fun getHardwareArchitecture(): String {
     return Build.HARDWARE
@@ -514,25 +518,58 @@ private class MuxDevice(ctx: Context) : IDevice {
     return "Android"
   }
 
-  override fun getMuxOSFamily(): String? = overwrittenOsFamilyName
+  @Deprecated(
+    message = "Mux core does not use this value anymore.",
+    replaceWith = ReplaceWith("CustomerViewerData")
+  )
+  override fun getMuxOSFamily(): String? = ""
 
   override fun getOSVersion(): String {
     return Build.VERSION.RELEASE + " (" + Build.VERSION.SDK_INT + ")"
   }
 
-  override fun getMuxOSVersion(): String? = overwrittenOsVersion
+  @Deprecated(
+    message = "Mux core does not use this value anymore.",
+    replaceWith = ReplaceWith("CustomerViewerData")
+  )
+  override fun getMuxOSVersion(): String? = ""
+
+  override fun getDeviceName(): String = ""
+
+  @Deprecated(
+    message = "Mux core does not use this value anymore.",
+    replaceWith = ReplaceWith("CustomerViewerData")
+  )
+  override fun getMuxDeviceName(): String = ""
+
+  override fun getDeviceCategory(): String {
+    TODO("Not yet implemented")
+  }
+
+  @Deprecated(
+    message = "Mux core does not use this value anymore.",
+    replaceWith = ReplaceWith("CustomerViewerData")
+  )
+  override fun getMuxDeviceCategory(): String = ""
 
   override fun getManufacturer(): String {
     return Build.MANUFACTURER
   }
 
-  override fun getMuxManufacturer(): String? = overwrittenManufacturer
+  @Deprecated(
+    message = "Mux core does not use this value anymore.",
+    replaceWith = ReplaceWith("CustomerViewerData")
+  )
+  override fun getMuxManufacturer(): String? = ""
 
   override fun getModelName(): String {
     return Build.MODEL
   }
 
-  override fun getMuxModelName(): String? = overwrittenDeviceName
+  /**
+   * @Deprecated, use {@Link CustomerViewerData} instead.
+   */
+  override fun getMuxModelName(): String? = ""
 
   override fun getPlayerVersion(): String {
     return ExoPlayerLibraryInfo.VERSION
@@ -607,6 +644,10 @@ private class MuxDevice(ctx: Context) : IDevice {
 
   override fun getElapsedRealtime(): Long {
     return SystemClock.elapsedRealtime()
+  }
+
+  override fun outputLog(p0: LogPriority?, p1: String?, p2: String?, p3: Throwable?) {
+    TODO("Not yet implemented")
   }
 
   override fun outputLog(logPriority: LogPriority, tag: String, msg: String) {

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
@@ -646,8 +646,15 @@ private class MuxDevice(ctx: Context) : IDevice {
     return SystemClock.elapsedRealtime()
   }
 
-  override fun outputLog(p0: LogPriority?, p1: String?, p2: String?, p3: Throwable?) {
-    TODO("Not yet implemented")
+  override fun outputLog(logPriority: LogPriority?, tag: String?, msg: String?, t: Throwable?) {
+    when (logPriority) {
+      LogPriority.ERROR -> Log.e(tag, msg, t)
+      LogPriority.WARN -> Log.w(tag, msg, t)
+      LogPriority.INFO -> Log.i(tag, msg, t)
+      LogPriority.DEBUG -> Log.d(tag, msg, t)
+      LogPriority.VERBOSE -> Log.v(tag, msg, t)
+      else -> Log.v(tag, msg, t)
+    }
   }
 
   override fun outputLog(logPriority: LogPriority, tag: String, msg: String) {

--- a/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/SimplePlayerBaseActivity.java
+++ b/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/SimplePlayerBaseActivity.java
@@ -31,7 +31,10 @@ import com.google.android.exoplayer2.ui.PlayerView;
 import com.mux.stats.sdk.core.model.CustomerData;
 import com.mux.stats.sdk.core.model.CustomerPlayerData;
 import com.mux.stats.sdk.core.model.CustomerVideoData;
+import com.mux.stats.sdk.core.model.CustomerViewData;
+import com.mux.stats.sdk.core.model.CustomerViewerData;
 import com.mux.stats.sdk.muxstats.automatedtests.BuildConfig;
+import com.mux.stats.sdk.muxstats.automatedtests.PlaybackTests;
 import com.mux.stats.sdk.muxstats.automatedtests.R;
 import com.mux.stats.sdk.muxstats.automatedtests.mockup.MockNetworkRequest;
 
@@ -205,6 +208,14 @@ public abstract class SimplePlayerBaseActivity extends AppCompatActivity {
     customerVideoData.setVideoTitle(videoTitle);
     mockNetwork = new MockNetworkRequest();
     CustomerData customerData = new CustomerData(customerPlayerData, customerVideoData, null);
+    CustomerViewerData customerViewerData = new CustomerViewerData();
+    customerViewerData.setMuxViewerDeviceCategory(PlaybackTests.DEVICE_CATEGORY_OVERRIDE);
+    customerViewerData.setMuxViewerDeviceManufacturer(PlaybackTests.DEVICE_MANUFACTURER_OVERRIDE);
+    customerViewerData.setMuxViewerDeviceModel(PlaybackTests.DEVICE_MODEL_OVERRIDE);
+    customerViewerData.setMuxViewerDeviceName(PlaybackTests.DEVICE_NAME_OVERRIDE);
+    customerViewerData.setMuxViewerOsFamily(PlaybackTests.DEVICE_OS_FAMILY_OVERRIDE);
+    customerViewerData.setMuxViewerOsVersion(PlaybackTests.DEVICE_OS_VERSION_OVERRIDE);
+    customerData.setCustomerViewerData(customerViewerData);
     muxStats = new MuxStatsExoPlayer(
         this, (ExoPlayer) player, playerView, "demo-player", customerData, null, mockNetwork);
     Point size = new Point();

--- a/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/PlaybackTests.java
+++ b/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/PlaybackTests.java
@@ -16,7 +16,9 @@ import com.mux.stats.sdk.core.events.playback.RebufferStartEvent;
 import com.mux.stats.sdk.core.events.playback.ViewEndEvent;
 import com.mux.stats.sdk.core.events.playback.ViewStartEvent;
 import com.mux.stats.sdk.core.model.CustomerVideoData;
+import com.mux.stats.sdk.core.model.CustomerViewerData;
 import com.mux.stats.sdk.core.model.PlayerData;
+import com.mux.stats.sdk.core.model.ViewerData;
 import com.mux.stats.sdk.muxstats.MuxStatsExoPlayer;
 
 import org.json.JSONArray;
@@ -37,6 +39,13 @@ public class PlaybackTests extends TestBase {
 
   public static final String TAG = "playbackTest";
   static final String secondVideoToPlayUrl = "http://localhost:5000/hls/google_glass/playlist.m3u8";
+
+  public static final String DEVICE_CATEGORY_OVERRIDE = "Mux test tablet";
+  public static final String DEVICE_MANUFACTURER_OVERRIDE = "Mux";
+  public static final String DEVICE_NAME_OVERRIDE = "Mux test";
+  public static final String DEVICE_OS_FAMILY_OVERRIDE = "Mux test OS";
+  public static final String DEVICE_OS_VERSION_OVERRIDE = "2.15";
+  public static final String DEVICE_MODEL_OVERRIDE = "Mux test model";
 
   @Test
   public void testVideoChange() {
@@ -84,6 +93,7 @@ public class PlaybackTests extends TestBase {
               + networkRequest.getReceivedEventNames());
         }
       }
+      checkOverwrites();
     } catch (Exception e) {
       fail(getExceptionFullTraceAndMessage(e));
     }
@@ -120,6 +130,7 @@ public class PlaybackTests extends TestBase {
             + ", viewEndEventIndex: " + viewEndEventIndex
             + ", pauseEventIndex: " + pauseIndex);
       }
+      checkOverwrites();
     } catch (Exception e) {
       fail(getExceptionFullTraceAndMessage(e));
     }
@@ -217,6 +228,7 @@ public class PlaybackTests extends TestBase {
       // TODO see how to handle that
 //      Log.w(TAG, "See what event should be dispatched on view closed !!!");
 //      checkFullScreenValue();
+      checkOverwrites();
     } catch (Exception e) {
       fail(getExceptionFullTraceAndMessage(e));
     }
@@ -298,6 +310,7 @@ public class PlaybackTests extends TestBase {
             + networkRequest.getReceivedEventNames());
       }
       // TODO see what is the best way to calculate rebuffer period
+      checkOverwrites();
     } catch (Exception e) {
       fail(getExceptionFullTraceAndMessage(e));
     }
@@ -322,5 +335,79 @@ public class PlaybackTests extends TestBase {
       }
     }
     fail("PlayerData.PLAYER_IS_FULLSCREEN field not present, this is an error !!!");
+  }
+
+  /**
+   * Goes trough all the events received and look for at least one occurence of value set for
+   * overwrite in ViewerData object.
+   *
+   * @throws JSONException
+   */
+  void checkOverwrites() throws JSONException {
+    boolean categoryOverwriteFound = false;
+    boolean manufacturerOverwriteFound = false;
+    boolean nameOverwriteFound = false;
+    boolean osFamilyOverwriteFound = false;
+    boolean osVersionOverwriteFound = false;
+    boolean modelOverwriteFound = false;
+    JSONArray eventsJa = networkRequest.getReceivedEventsAsJSON();
+    for (int index = 0; index < eventsJa.length(); index++) {
+      JSONObject eventJo = eventsJa.getJSONObject(index);
+      if (checkTheValueForKey(eventJo, CustomerViewerData.MUX_VIEWER_DEVICE_CATEGORY,
+          DEVICE_CATEGORY_OVERRIDE)) {
+        categoryOverwriteFound = true;
+      }
+      if (checkTheValueForKey(eventJo, CustomerViewerData.MUX_VIEWER_DEVICE_MANUFACTURER,
+          DEVICE_MANUFACTURER_OVERRIDE)) {
+        manufacturerOverwriteFound = true;
+      }
+      if (checkTheValueForKey(eventJo, CustomerViewerData.MUX_VIEWER_DEVICE_NAME,
+          DEVICE_NAME_OVERRIDE)) {
+        nameOverwriteFound = true;
+      }
+      if (checkTheValueForKey(eventJo, CustomerViewerData.MUX_VIEWER_OS_FAMILY,
+          DEVICE_OS_FAMILY_OVERRIDE)) {
+        osFamilyOverwriteFound = true;
+      }
+      if (checkTheValueForKey(eventJo, CustomerViewerData.MUX_VIEWER_OS_VERSION,
+          DEVICE_OS_VERSION_OVERRIDE)) {
+        osVersionOverwriteFound = true;
+      }
+      if (checkTheValueForKey(eventJo, CustomerViewerData.MUX_VIEWER_DEVICE_MODEL,
+          DEVICE_MODEL_OVERRIDE)) {
+        modelOverwriteFound = true;
+      }
+    }
+    if (!(
+        categoryOverwriteFound &&
+            manufacturerOverwriteFound &&
+            nameOverwriteFound &&
+            osFamilyOverwriteFound &&
+            osVersionOverwriteFound &&
+            modelOverwriteFound
+    )) {
+      fail("Missing one of the value set for overwrite, result: \n" +
+          "categoryOverwriteFound: " + categoryOverwriteFound + "\n" +
+          "manufacturerOverwriteFound: " + manufacturerOverwriteFound + "\n" +
+          "nameOverwriteFound: " + nameOverwriteFound + "\n" +
+          "osFamilyOverwriteFound: " + osFamilyOverwriteFound + "\n" +
+          "osVersionOverwriteFound: " + osVersionOverwriteFound + "\n" +
+          "modelOverwriteFound: " + modelOverwriteFound + "\n"
+      );
+    }
+  }
+
+  private boolean checkTheValueForKey(JSONObject jo, String key, String expValue)
+      throws JSONException {
+    if (jo.has(key)) {
+      String value = jo.getString(key);
+      if (!expValue.equals(value)) {
+        fail("Check failed for key: " + key + "\n" +
+            "Valuie found: " + value + "\n" +
+            "Expected: " + expValue);
+      }
+      return true;
+    }
+    return false;
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ allprojects {
     compileSdkVersion = 31
     targetSdkVersion = 31
 
-    muxCoreVersion = "7.3.2"
+    muxCoreVersion = "dev-overriding_device_data_new_api-2e93134"
     kotlinxCoroutinesVersion = "1.6.1"
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ allprojects {
     compileSdkVersion = 31
     targetSdkVersion = 31
 
-    muxCoreVersion = "dev-overriding_device_data_new_api-2e93134"
+    muxCoreVersion = "7.5.0"
     kotlinxCoroutinesVersion = "1.6.1"
   }
 }


### PR DESCRIPTION
MUX_VIEWER_DEVICE_CATEGORY = "mvrdvcg";
MUX_VIEWER_DEVICE_MANUFACTURER = "mvrdvmn";
MUX_VIEWER_DEVICE_NAME = "mvrdvnm";
MUX_VIEWER_OS_FAMILY = "mvrosfm";
MUX_VIEWER_OS_VERSION = "mvrosve";
MUX_VIEWER_DEVICE_MODEL = "mvrdvmo";

These values are now propagated to the backend via the CustomerData API, tested.