### PR TITLE
Improve Error Code Variety on ExoPlayer 2.15+

### DIFF
--- a/ExoPlayerAdapter/src/exo-error-2_15-now/java/com/mux/stats/sdk/muxstats/ExoErrorMetrics215ToNow.kt
+++ b/ExoPlayerAdapter/src/exo-error-2_15-now/java/com/mux/stats/sdk/muxstats/ExoErrorMetrics215ToNow.kt
@@ -36,41 +36,10 @@ private class ExoErrorMetricsByListener215ToNow : MuxPlayerAdapter.PlayerBinding
 private class ErrorPlayerListenerUpTo214(val collector: MuxStateCollector) : Player.Listener {
   override fun onPlayerError(error: PlaybackException) {
     if (error is ExoPlaybackException) {
-      collector.handleExoPlaybackException(error)
+      collector.handleExoPlaybackException(error.errorCode, error)
     } else {
-      var errorCode = ExoPlaybackException.TYPE_UNEXPECTED
-      val errorMessage = "${error.errorCodeName}: ${error.message}"
-      when (error.errorCode) {
-        PlaybackException.ERROR_CODE_REMOTE_ERROR -> errorCode = ExoPlaybackException.TYPE_REMOTE
-        PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS,
-        PlaybackException.ERROR_CODE_IO_CLEARTEXT_NOT_PERMITTED,
-        PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND,
-        PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE,
-        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
-        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT,
-        PlaybackException.ERROR_CODE_IO_NO_PERMISSION,
-        PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE,
-        PlaybackException.ERROR_CODE_IO_UNSPECIFIED,
-        PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED,
-        PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED,
-        PlaybackException.ERROR_CODE_PARSING_MANIFEST_MALFORMED,
-        PlaybackException.ERROR_CODE_PARSING_MANIFEST_UNSUPPORTED,
-        PlaybackException.ERROR_CODE_DRM_CONTENT_ERROR,
-        PlaybackException.ERROR_CODE_DRM_UNSPECIFIED,
-        PlaybackException.ERROR_CODE_DRM_SCHEME_UNSUPPORTED,
-        PlaybackException.ERROR_CODE_DRM_PROVISIONING_FAILED,
-        PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED,
-        PlaybackException.ERROR_CODE_DRM_DISALLOWED_OPERATION,
-        PlaybackException.ERROR_CODE_DRM_SYSTEM_ERROR,
-        PlaybackException.ERROR_CODE_DRM_DEVICE_REVOKED,
-        PlaybackException.ERROR_CODE_DRM_LICENSE_EXPIRED -> errorCode =
-          ExoPlaybackException.TYPE_SOURCE
-        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED, PlaybackException.ERROR_CODE_DECODER_QUERY_FAILED, PlaybackException.ERROR_CODE_DECODING_FAILED, PlaybackException.ERROR_CODE_DECODING_FORMAT_UNSUPPORTED, PlaybackException.ERROR_CODE_DECODING_FORMAT_EXCEEDS_CAPABILITIES, PlaybackException.ERROR_CODE_AUDIO_TRACK_INIT_FAILED, PlaybackException.ERROR_CODE_AUDIO_TRACK_WRITE_FAILED -> errorCode =
-          ExoPlaybackException.TYPE_RENDERER
-        else -> {}
-      }
-
-      collector.internalError(MuxErrorException(errorCode, errorMessage))
+      val errorMessage = "${error.errorCode}: ${error.message}"
+      collector.internalError(MuxErrorException(error.errorCode, errorMessage))
     }
   }
 }

--- a/ExoPlayerAdapter/src/exo-error-just-2_14/java/com/mux/stats/sdk/muxstats/ExoErrorMetricsUpTo214.kt
+++ b/ExoPlayerAdapter/src/exo-error-just-2_14/java/com/mux/stats/sdk/muxstats/ExoErrorMetricsUpTo214.kt
@@ -37,7 +37,7 @@ private class ExoErrorMetricsByListenerJust214 : MuxPlayerAdapter.PlayerBinding<
 
 private class ErrorPlayerListenerUpTo214(val collector: MuxStateCollector) : Player.Listener {
   override fun onPlayerError(error: ExoPlaybackException) {
-    collector.handleExoPlaybackException(error)
+    collector.handleExoPlaybackException(error.type, error)
   }
 }
 

--- a/ExoPlayerAdapter/src/exo-error-upto-2_13/java/com/mux/stats/sdk/muxstats/ExoErrorMetricsUpTo214.kt
+++ b/ExoPlayerAdapter/src/exo-error-upto-2_13/java/com/mux/stats/sdk/muxstats/ExoErrorMetricsUpTo214.kt
@@ -37,7 +37,7 @@ private class ExoErrorMetricsByListenerUpTo213 : MuxPlayerAdapter.PlayerBinding<
 
 private class ErrorPlayerListenerUpTo214(val collector: MuxStateCollector) : Player.EventListener {
   override fun onPlayerError(error: ExoPlaybackException) {
-    collector.handleExoPlaybackException(error)
+    collector.handleExoPlaybackException(error.type, error)
   }
 }
 

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/Util.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/Util.kt
@@ -126,11 +126,11 @@ internal fun MuxStateCollector.handleExoPlaybackException(e: ExoPlaybackExceptio
         // TODO split this by versions and implement else block to ghet the codec details
 //      if (die.codecInfo == null) {
         if (die.cause is MediaCodecUtil.DecoderQueryException) {
-          internalError(MuxErrorException(e.type, "Unable to query device decoders"))
+          internalError(MuxErrorException(e.errorCode, "Unable to query device decoders"))
         } else if (die.secureDecoderRequired) {
-          internalError(MuxErrorException(e.type, "No secure decoder for " + die.mimeType))
+          internalError(MuxErrorException(e.errorCode, "No secure decoder for " + die.mimeType))
         } else {
-          internalError(MuxErrorException(e.type, "No decoder for " + die.mimeType))
+          internalError(MuxErrorException(e.errorCode, "No decoder for " + die.mimeType))
         }
 //      }
 //    else {
@@ -141,7 +141,7 @@ internal fun MuxStateCollector.handleExoPlaybackException(e: ExoPlaybackExceptio
     } else {
       internalError(
         MuxErrorException(
-          e.type,
+          e.errorCode,
           "${cause.javaClass.canonicalName} - ${cause.message}"
         )
       )
@@ -150,7 +150,7 @@ internal fun MuxStateCollector.handleExoPlaybackException(e: ExoPlaybackExceptio
     val error: Exception = e.sourceException
     internalError(
       MuxErrorException(
-        e.type,
+        e.errorCode,
         "${error.javaClass.canonicalName} - ${error.message}"
       )
     )
@@ -158,7 +158,7 @@ internal fun MuxStateCollector.handleExoPlaybackException(e: ExoPlaybackExceptio
     val error: Exception = e.unexpectedException
     internalError(
       MuxErrorException(
-        e.type,
+        e.errorCode,
         "${error.javaClass.canonicalName} - ${error.message}"
       )
     )

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/Util.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/internal/Util.kt
@@ -163,7 +163,12 @@ internal fun MuxStateCollector.handleExoPlaybackException(e: ExoPlaybackExceptio
       )
     )
   } else {
-    internalError(e)
+    internalError(
+      MuxErrorException(
+        e.errorCode,
+        "${e.javaClass.canonicalName} - ${e.message}"
+      )
+    )
   }
 }
 


### PR DESCRIPTION
We can report many more error codes on ExoPlayer 2.15 and higher, but haven't been for the sake of consistency. A customer has requested more verbose error codes and this will forward on all the error codes in [PlaybackException](https://github.com/google/ExoPlayer/blob/release-v2/library/common/src/main/java/com/google/android/exoplayer2/PlaybackException.java), a significant improvement

This change isn't backward-compatible, in the sense that all these error codes would be considered "new" on customer dashboards, but the extra information will be a lot more useful.