### PR TITLE
fix: rename package for (internal) ExoPlayerAdapter classes

### DIFF
--- a/ExoPlayerAdapter/build.gradle
+++ b/ExoPlayerAdapter/build.gradle
@@ -11,6 +11,8 @@ android {
     minSdk project.ext.minSdkVersion
     targetSdk project.ext.targetSdkVersion
 
+    multiDexEnabled true
+
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles "consumer-rules.pro"
   }

--- a/ExoPlayerAdapter/src/exo-analytics-2_19-now/java/com/mux/stats/sdk/muxstats/AnalyticsListenerMetrics.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-2_19-now/java/com/mux/stats/sdk/muxstats/AnalyticsListenerMetrics.kt
@@ -3,9 +3,10 @@ package com.mux.stats.sdk.muxstats
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.analytics.AnalyticsListener
 import com.mux.stats.sdk.core.util.MuxLogger
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.watchContentPosition
 import com.mux.stats.sdk.muxstats.internal.exoAnalyticsListener
-import com.mux.stats.sdk.muxstats.internal.logTag
-import com.mux.stats.sdk.muxstats.internal.watchContentPosition
 
 /**
  * Binding to an ExoPlayer using AnalyticsListener

--- a/ExoPlayerAdapter/src/exo-analytics-2_19-now/java/com/mux/stats/sdk/muxstats/SessionDataBindings.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-2_19-now/java/com/mux/stats/sdk/muxstats/SessionDataBindings.kt
@@ -5,8 +5,9 @@ import com.google.android.exoplayer2.analytics.AnalyticsListener
 import com.google.android.exoplayer2.source.hls.HlsManifest
 import com.mux.stats.sdk.core.model.SessionTag
 import com.mux.stats.sdk.core.util.MuxLogger
-import com.mux.stats.sdk.muxstats.internal.isHlsExtensionAvailable
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.isHlsExtensionAvailable
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 

--- a/ExoPlayerAdapter/src/exo-analytics-just2_16/java/com/mux/stats/sdk/muxstats/AnalyticsListenerMetrics.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-just2_16/java/com/mux/stats/sdk/muxstats/AnalyticsListenerMetrics.kt
@@ -3,9 +3,10 @@ package com.mux.stats.sdk.muxstats
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.analytics.AnalyticsListener
 import com.mux.stats.sdk.core.util.MuxLogger
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.watchContentPosition
 import com.mux.stats.sdk.muxstats.internal.exoAnalyticsListener
-import com.mux.stats.sdk.muxstats.internal.logTag
-import com.mux.stats.sdk.muxstats.internal.watchContentPosition
 
 /**
  * Binding to an ExoPlayer using AnalyticsListener

--- a/ExoPlayerAdapter/src/exo-analytics-just2_16/java/com/mux/stats/sdk/muxstats/SessionDataBindings.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-just2_16/java/com/mux/stats/sdk/muxstats/SessionDataBindings.kt
@@ -5,8 +5,9 @@ import com.google.android.exoplayer2.analytics.AnalyticsListener
 import com.google.android.exoplayer2.source.hls.HlsManifest
 import com.mux.stats.sdk.core.model.SessionTag
 import com.mux.stats.sdk.core.util.MuxLogger
-import com.mux.stats.sdk.muxstats.internal.isHlsExtensionAvailable
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.isHlsExtensionAvailable
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 

--- a/ExoPlayerAdapter/src/exo-analytics-listener-2_13-2_16/java/com/mux/stats/sdk/muxstats/internal/ExoAnalyticsListener.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-listener-2_13-2_16/java/com/mux/stats/sdk/muxstats/internal/ExoAnalyticsListener.kt
@@ -11,6 +11,11 @@ import com.google.android.exoplayer2.source.MediaLoadData
 import com.google.android.exoplayer2.source.TrackGroupArray
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray
 import com.mux.stats.sdk.muxstats.MuxStateCollector
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.BandwidthMetricDispatcher
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.MuxMediaHasVideoTrack
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.handleExoPlaybackState
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.handlePositionDiscontinuityBefore218
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 import java.io.IOException
 
 /**

--- a/ExoPlayerAdapter/src/exo-analytics-listener-2_18-now/java/com/mux/stats/sdk/muxstats/internal/ExoAnalyticsListener.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-listener-2_18-now/java/com/mux/stats/sdk/muxstats/internal/ExoAnalyticsListener.kt
@@ -7,8 +7,13 @@ import com.google.android.exoplayer2.source.LoadEventInfo
 import com.google.android.exoplayer2.source.MediaLoadData
 import com.google.android.exoplayer2.source.TrackGroupArray
 import com.google.android.exoplayer2.video.VideoSize
-import com.mux.stats.sdk.muxstats.MuxPlayerState
 import com.mux.stats.sdk.muxstats.MuxStateCollector
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerState
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.BandwidthMetricDispatcher
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.MuxMediaHasVideoTrack
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.handleExoPlaybackState
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.handlePositionDiscontinuity
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 import java.io.IOException
 
 /**

--- a/ExoPlayerAdapter/src/exo-analytics-listener-just-2_17/java/com/mux/stats/sdk/muxstats/internal/ExoAnalyticsListener.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-listener-just-2_17/java/com/mux/stats/sdk/muxstats/internal/ExoAnalyticsListener.kt
@@ -1,6 +1,5 @@
 package com.mux.stats.sdk.muxstats.internal
 
-import android.view.Surface
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.Format
 import com.google.android.exoplayer2.PlaybackParameters
@@ -12,6 +11,11 @@ import com.google.android.exoplayer2.source.MediaLoadData
 import com.google.android.exoplayer2.source.TrackGroupArray
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray
 import com.mux.stats.sdk.muxstats.MuxStateCollector
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.BandwidthMetricDispatcher
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.MuxMediaHasVideoTrack
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.handleExoPlaybackState
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.handlePositionDiscontinuityBefore218
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 import java.io.IOException
 
 /**

--- a/ExoPlayerAdapter/src/exo-analytics-upto-2_16/java/com/mux/stats/sdk/muxstats/AnalyticsListenerMetrics.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-upto-2_16/java/com/mux/stats/sdk/muxstats/AnalyticsListenerMetrics.kt
@@ -4,10 +4,10 @@ import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.analytics.AnalyticsListener
 import com.mux.stats.sdk.core.util.MuxLogger
 import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
-import com.mux.stats.sdk.muxstats.internal.exoAnalyticsListener
 import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
 import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.watchContentPosition
 import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
+import com.mux.stats.sdk.muxstats.internal.exoAnalyticsListener
 
 private class AnalyticsListenerBindingUpTo16 : MuxPlayerAdapter.PlayerBinding<SimpleExoPlayer> {
 

--- a/ExoPlayerAdapter/src/exo-analytics-upto-2_16/java/com/mux/stats/sdk/muxstats/AnalyticsListenerMetrics.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-upto-2_16/java/com/mux/stats/sdk/muxstats/AnalyticsListenerMetrics.kt
@@ -3,10 +3,11 @@ package com.mux.stats.sdk.muxstats
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.analytics.AnalyticsListener
 import com.mux.stats.sdk.core.util.MuxLogger
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
 import com.mux.stats.sdk.muxstats.internal.exoAnalyticsListener
-import com.mux.stats.sdk.muxstats.internal.logTag
-import com.mux.stats.sdk.muxstats.internal.watchContentPosition
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.watchContentPosition
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 
 private class AnalyticsListenerBindingUpTo16 : MuxPlayerAdapter.PlayerBinding<SimpleExoPlayer> {
 

--- a/ExoPlayerAdapter/src/exo-analytics-upto-2_16/java/com/mux/stats/sdk/muxstats/SessionDataBindings.kt
+++ b/ExoPlayerAdapter/src/exo-analytics-upto-2_16/java/com/mux/stats/sdk/muxstats/SessionDataBindings.kt
@@ -6,8 +6,9 @@ import com.google.android.exoplayer2.analytics.AnalyticsListener
 import com.google.android.exoplayer2.source.hls.HlsManifest
 import com.mux.stats.sdk.core.model.SessionTag
 import com.mux.stats.sdk.core.util.MuxLogger
-import com.mux.stats.sdk.muxstats.internal.isHlsExtensionAvailable
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.isHlsExtensionAvailable
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 

--- a/ExoPlayerAdapter/src/exo-collector-2_10-now/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
+++ b/ExoPlayerAdapter/src/exo-collector-2_10-now/java/com/mux/stats/sdk/muxstats/MuxStateCollector.kt
@@ -2,6 +2,7 @@ package com.mux.stats.sdk.muxstats
 
 import com.google.android.exoplayer2.source.hls.HlsManifest
 import com.mux.stats.sdk.core.events.IEventDispatcher
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxStateCollectorBase
 
 open class MuxStateCollector(
     private val _muxStats: () -> MuxStats,

--- a/ExoPlayerAdapter/src/exo-error-2_15-now/java/com/mux/stats/sdk/muxstats/ExoErrorMetrics215ToNow.kt
+++ b/ExoPlayerAdapter/src/exo-error-2_15-now/java/com/mux/stats/sdk/muxstats/ExoErrorMetrics215ToNow.kt
@@ -5,9 +5,10 @@ import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.PlaybackException
 import com.google.android.exoplayer2.Player
 import com.mux.stats.sdk.core.util.MuxLogger
-import com.mux.stats.sdk.muxstats.internal.handleExoPlaybackException
-import com.mux.stats.sdk.muxstats.internal.logTag
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.handleExoPlaybackException
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 
 /**
  * Player binding for  exoplayer android metrics

--- a/ExoPlayerAdapter/src/exo-error-just-2_14/java/com/mux/stats/sdk/muxstats/ExoErrorMetricsUpTo214.kt
+++ b/ExoPlayerAdapter/src/exo-error-just-2_14/java/com/mux/stats/sdk/muxstats/ExoErrorMetricsUpTo214.kt
@@ -4,9 +4,10 @@ import com.google.android.exoplayer2.ExoPlaybackException
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.Player
 import com.mux.stats.sdk.core.util.MuxLogger
-import com.mux.stats.sdk.muxstats.internal.handleExoPlaybackException
-import com.mux.stats.sdk.muxstats.internal.logTag
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.handleExoPlaybackException
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 
 /**
  * Player binding for  exoplayer android metrics

--- a/ExoPlayerAdapter/src/exo-event-2_14-now/java/com/mux/stats/sdk/muxstats/BasicExoMetrics14toNow.kt
+++ b/ExoPlayerAdapter/src/exo-event-2_14-now/java/com/mux/stats/sdk/muxstats/BasicExoMetrics14toNow.kt
@@ -6,11 +6,12 @@ import com.google.android.exoplayer2.Timeline
 import com.google.android.exoplayer2.source.TrackGroupArray
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray
 import com.mux.stats.sdk.core.util.MuxLogger
-import com.mux.stats.sdk.muxstats.internal.*
-import com.mux.stats.sdk.muxstats.internal.handleExoPlaybackState
-import com.mux.stats.sdk.muxstats.internal.logTag
-import com.mux.stats.sdk.muxstats.internal.watchContentPosition
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.handleExoPlaybackState
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.handlePositionDiscontinuity
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.watchContentPosition
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 
 /**
  * Player binding for basic ExoPlayer metrics.

--- a/ExoPlayerAdapter/src/exo-mediaitem-2_14-now/java/com/mux/stats/sdk/muxstats/ExoPlayerAdTagExtensions.kt
+++ b/ExoPlayerAdapter/src/exo-mediaitem-2_14-now/java/com/mux/stats/sdk/muxstats/ExoPlayerAdTagExtensions.kt
@@ -4,7 +4,7 @@ import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
 
 /*
- * # ExoPlayerExt.kt: Useful extensions on [ExoPlayer].
+ * # ExoPlayerAdTagExtensions.kt: Useful extensions on [ExoPlayer].
  */
 
 /**

--- a/ExoPlayerAdapter/src/exo-player-2_16-now/java/com/mux/stats/sdk/muxstats/PlayerStateMetrics216ToNow.kt
+++ b/ExoPlayerAdapter/src/exo-player-2_16-now/java/com/mux/stats/sdk/muxstats/PlayerStateMetrics216ToNow.kt
@@ -2,8 +2,9 @@ package com.mux.stats.sdk.muxstats
 
 import com.google.android.exoplayer2.ExoPlayer
 import com.mux.stats.sdk.core.util.MuxLogger
-import com.mux.stats.sdk.muxstats.internal.logTag
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 
 /**
  * Binding for Player State metrics.

--- a/ExoPlayerAdapter/src/exo-player-upto-2_15/java/com/mux/stats/sdk/muxstats/PlayerStateMetricsUpTo215.kt
+++ b/ExoPlayerAdapter/src/exo-player-upto-2_15/java/com/mux/stats/sdk/muxstats/PlayerStateMetricsUpTo215.kt
@@ -3,9 +3,10 @@ package com.mux.stats.sdk.muxstats
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.mux.stats.sdk.core.util.MuxLogger
-import com.mux.stats.sdk.muxstats.internal.logTag
-import com.mux.stats.sdk.muxstats.internal.watchContentPosition
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.watchContentPosition
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 
 /**
  * Binding for Player State metrics.

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/MuxPlayerAdapter.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/MuxPlayerAdapter.kt
@@ -1,7 +1,8 @@
-package com.mux.stats.sdk.muxstats
+package com.mux.stats.sdk.muxstats.exoplayeradapter
 
-import com.mux.stats.sdk.muxstats.internal.observableWeak
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.MuxStateCollector
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.observableWeak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 
 /**
  * Adapts a player framework to a {@link MuxDataPlayer}, passing events between them

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/MuxPlayerState.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/MuxPlayerState.kt
@@ -1,4 +1,4 @@
-package com.mux.stats.sdk.muxstats
+package com.mux.stats.sdk.muxstats.exoplayeradapter
 
 /**
  * Player states as seen by Mux Data for the purpose of generating metrics

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/MuxStateCollectorBase.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/MuxStateCollectorBase.kt
@@ -1,4 +1,4 @@
-package com.mux.stats.sdk.muxstats
+package com.mux.stats.sdk.muxstats.exoplayeradapter
 
 import com.google.android.exoplayer2.Timeline
 import com.mux.stats.sdk.core.events.IEvent
@@ -9,10 +9,12 @@ import com.mux.stats.sdk.core.model.BandwidthMetricData
 import com.mux.stats.sdk.core.model.CustomerVideoData
 import com.mux.stats.sdk.core.model.SessionTag
 import com.mux.stats.sdk.core.util.MuxLogger
-import com.mux.stats.sdk.muxstats.internal.BandwidthMetricDispatcher
-import com.mux.stats.sdk.muxstats.internal.logTag
-import com.mux.stats.sdk.muxstats.internal.noneOf
-import com.mux.stats.sdk.muxstats.internal.oneOf
+import com.mux.stats.sdk.muxstats.MuxErrorException
+import com.mux.stats.sdk.muxstats.MuxStats
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.BandwidthMetricDispatcher
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.noneOf
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.oneOf
 import kotlinx.coroutines.*
 import java.util.*
 import java.util.regex.Pattern

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/MuxUiDelegate.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/MuxUiDelegate.kt
@@ -1,15 +1,13 @@
-package com.mux.stats.sdk.muxstats
+package com.mux.stats.sdk.muxstats.exoplayeradapter
 
 import android.annotation.TargetApi
 import android.app.Activity
 import android.graphics.Point
 import android.os.Build
-import android.util.Log
 import android.view.View
 import android.view.WindowInsets
-import com.google.android.exoplayer2.ui.PlayerView
 import com.mux.stats.sdk.core.util.MuxLogger
-import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.weak
 
 
 /**

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/internal/BandwidthMetric.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/internal/BandwidthMetric.kt
@@ -1,4 +1,4 @@
-package com.mux.stats.sdk.muxstats.internal
+package com.mux.stats.sdk.muxstats.exoplayeradapter.internal
 
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.ExoPlayer
@@ -228,7 +228,7 @@ internal class BandwidthMetricDispatcher(player: ExoPlayer,
 ) {
     private val player: ExoPlayer? by weak(player)
     private val collector: MuxStateCollector? by weak(collector)
-    protected var bandwidthMetricHls:BandwidthMetricHls = BandwidthMetricHls(player, collector)
+    protected var bandwidthMetricHls: BandwidthMetricHls = BandwidthMetricHls(player, collector)
     protected var debugModeOn:Boolean = false
     protected var requestSegmentDuration:Long = 1000
     protected var lastRequestSentAt:Long = -1

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/internal/BasicExoPlayerBindings.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/internal/BasicExoPlayerBindings.kt
@@ -1,10 +1,14 @@
-package com.mux.stats.sdk.muxstats.internal
+package com.mux.stats.sdk.muxstats.exoplayeradapter.internal
 
 import android.app.Activity
 import android.content.Context
 import android.view.View
 import com.google.android.exoplayer2.ExoPlayer
 import com.mux.stats.sdk.muxstats.*
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxUiDelegate
+import com.mux.stats.sdk.muxstats.exoplayeradapter.muxUiDelegate
+import com.mux.stats.sdk.muxstats.exoplayeradapter.noUiDelegate
 
 /**
  * Generates PlayerBindings for ExoPlayer

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/internal/Util.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/internal/Util.kt
@@ -1,4 +1,4 @@
-package com.mux.stats.sdk.muxstats.internal
+package com.mux.stats.sdk.muxstats.exoplayeradapter.internal
 
 import com.google.android.exoplayer2.ExoPlaybackException
 import com.google.android.exoplayer2.ExoPlayer
@@ -11,9 +11,9 @@ import com.google.android.exoplayer2.source.TrackGroupArray
 import com.google.android.exoplayer2.source.hls.HlsManifest
 import com.mux.stats.sdk.core.util.MuxLogger
 import com.mux.stats.sdk.muxstats.MuxErrorException
-import com.mux.stats.sdk.muxstats.MuxPlayerState
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerState
 import com.mux.stats.sdk.muxstats.MuxStateCollector
-import com.mux.stats.sdk.muxstats.MuxStateCollectorBase
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxStateCollectorBase
 
 // -- General Utils --
 

--- a/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/internal/WeakRef.kt
+++ b/ExoPlayerAdapter/src/main/java/com/mux/stats/sdk/muxstats/exoplayeradapter/internal/WeakRef.kt
@@ -1,4 +1,4 @@
-package com.mux.stats.sdk.muxstats.internal
+package com.mux.stats.sdk.muxstats.exoplayeradapter.internal
 
 import java.lang.ref.WeakReference
 import kotlin.properties.ReadWriteProperty

--- a/ExoPlayerAdapter/src/test/java/com/mux/exoplayeradapter/PlayerAdapterTests.kt
+++ b/ExoPlayerAdapter/src/test/java/com/mux/exoplayeradapter/PlayerAdapterTests.kt
@@ -3,10 +3,10 @@ package com.mux.exoplayeradapter
 import android.view.View
 import com.mux.exoplayeradapter.double.FakePlayerBinding
 import com.mux.exoplayeradapter.double.UiDelegateMocks
-import com.mux.stats.sdk.muxstats.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
 import com.mux.stats.sdk.muxstats.MuxStateCollector
-import com.mux.stats.sdk.muxstats.MuxUiDelegate
-import com.mux.stats.sdk.muxstats.muxUiDelegate
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxUiDelegate
+import com.mux.stats.sdk.muxstats.exoplayeradapter.muxUiDelegate
 import io.mockk.*
 import org.junit.Test
 

--- a/ExoPlayerAdapter/src/test/java/com/mux/exoplayeradapter/StateCollectorTests.kt
+++ b/ExoPlayerAdapter/src/test/java/com/mux/exoplayeradapter/StateCollectorTests.kt
@@ -2,9 +2,9 @@ package com.mux.exoplayeradapter
 
 import com.mux.exoplayeradapter.double.FakeEventDispatcher
 import com.mux.stats.sdk.core.events.playback.*
-import com.mux.stats.sdk.muxstats.MuxPlayerState
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerState
 import com.mux.stats.sdk.muxstats.MuxStateCollector
-import com.mux.stats.sdk.muxstats.MuxStateCollectorBase
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxStateCollectorBase
 import com.mux.stats.sdk.muxstats.MuxStats
 import io.mockk.mockk
 import kotlinx.coroutines.delay

--- a/ExoPlayerAdapter/src/test/java/com/mux/exoplayeradapter/UiDelegateTests.kt
+++ b/ExoPlayerAdapter/src/test/java/com/mux/exoplayeradapter/UiDelegateTests.kt
@@ -1,7 +1,6 @@
 package com.mux.exoplayeradapter
 
 import android.app.Activity
-import android.content.Context
 import android.view.View
 import com.mux.exoplayeradapter.double.UiDelegateMocks.MOCK_PLAYER_HEIGHT
 import com.mux.exoplayeradapter.double.UiDelegateMocks.MOCK_PLAYER_WIDTH
@@ -9,8 +8,8 @@ import com.mux.exoplayeradapter.double.UiDelegateMocks.MOCK_SCREEN_HEIGHT
 import com.mux.exoplayeradapter.double.UiDelegateMocks.MOCK_SCREEN_WIDTH
 import com.mux.exoplayeradapter.double.UiDelegateMocks.mockActivity
 import com.mux.exoplayeradapter.double.UiDelegateMocks.mockView
-import com.mux.stats.sdk.muxstats.muxUiDelegate
-import com.mux.stats.sdk.muxstats.noUiDelegate
+import com.mux.stats.sdk.muxstats.exoplayeradapter.muxUiDelegate
+import com.mux.stats.sdk.muxstats.exoplayeradapter.noUiDelegate
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals

--- a/ExoPlayerAdapter/src/test/java/com/mux/exoplayeradapter/double/FakePlayerBinding.kt
+++ b/ExoPlayerAdapter/src/test/java/com/mux/exoplayeradapter/double/FakePlayerBinding.kt
@@ -1,9 +1,9 @@
 package com.mux.exoplayeradapter.double
 
 import com.mux.exoplayeradapter.log
-import com.mux.stats.sdk.muxstats.MuxPlayerAdapter
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerAdapter
 import com.mux.stats.sdk.muxstats.MuxStateCollector
-import com.mux.stats.sdk.muxstats.internal.logTag
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.logTag
 
 class FakePlayerBinding<Player>(val name: String) : MuxPlayerAdapter.PlayerBinding<Player> {
   override fun bindPlayer(player: Player, collector: MuxStateCollector) {

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/AdsImaSDKListener.kt
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/AdsImaSDKListener.kt
@@ -9,6 +9,7 @@ import com.mux.stats.sdk.core.events.playback.*
 import com.mux.stats.sdk.core.model.AdData
 import com.mux.stats.sdk.core.model.ViewData
 import com.mux.stats.sdk.core.util.MuxLogger
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerState
 import com.mux.stats.sdk.muxstats.internal.oneOf
 import com.mux.stats.sdk.muxstats.internal.weak
 import com.mux.stats.sdk.core.events.playback.AdEvent as MuxAdEvent

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/AdsImaSDKListener.kt
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/AdsImaSDKListener.kt
@@ -10,8 +10,8 @@ import com.mux.stats.sdk.core.model.AdData
 import com.mux.stats.sdk.core.model.ViewData
 import com.mux.stats.sdk.core.util.MuxLogger
 import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerState
-import com.mux.stats.sdk.muxstats.internal.oneOf
 import com.mux.stats.sdk.muxstats.internal.weak
+import com.mux.stats.sdk.muxstats.internal.oneOf
 import com.mux.stats.sdk.core.events.playback.AdEvent as MuxAdEvent
 
 /**

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
@@ -39,6 +39,9 @@ import com.mux.stats.sdk.core.model.CustomerData
 import com.mux.stats.sdk.core.model.CustomerPlayerData
 import com.mux.stats.sdk.core.model.CustomerVideoData
 import com.mux.stats.sdk.core.util.MuxLogger
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerState
+import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxUiDelegate
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.createExoPlayerAdapter
 import com.mux.stats.sdk.muxstats.internal.*
 import com.mux.stats.sdk.muxstats.internal.weak
 import java.lang.ref.WeakReference

--- a/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
+++ b/MuxExoPlayer/src/main/java/com/mux/stats/sdk/muxstats/MuxStatsExoPlayer.kt
@@ -42,7 +42,9 @@ import com.mux.stats.sdk.core.util.MuxLogger
 import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxPlayerState
 import com.mux.stats.sdk.muxstats.exoplayeradapter.MuxUiDelegate
 import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.createExoPlayerAdapter
-import com.mux.stats.sdk.muxstats.internal.*
+import com.mux.stats.sdk.muxstats.exoplayeradapter.internal.*
+import com.mux.stats.sdk.muxstats.internal.isDebugVariant
+import com.mux.stats.sdk.muxstats.internal.logTag
 import com.mux.stats.sdk.muxstats.internal.weak
 import java.lang.ref.WeakReference
 import java.util.*


### PR DESCRIPTION
In the ExoPlayer SDK, these are essentially internal. Even if a customer accessed the symbols, there's no public API to put then together into anything functional (the best that can be done in java sometimes). As such, we can freely change the package name or anything else.

and just as an aside, the media3-sdk versions of these classes are *not* internal (they're in the android core). This forces our hand, but I would have rather made this change anyway, since ExoPlayer is on the way out.